### PR TITLE
Update wc-sale-discord-notifications.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,70 +3,115 @@
 [![GitHub release](https://img.shields.io/github/release/Cral-Cactus/wc-sale-discord-notifications.svg)](https://github.com/Cral-Cactus/wc-sale-discord-notifications/releases)
 [![GitHub issues](https://img.shields.io/github/issues/Cral-Cactus/wc-sale-discord-notifications.svg)](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues/)
 
-This plugin sends a notification to a Discord channel whenever a sale is made on WooCommerce. It is highly customizable, allowing notifications for different order statuses and the ability to configure the webhook URL and message colors.
+> A powerful WooCommerce extension that sends order updates directly to your Discord server. Now with configurable message fields, status-specific webhooks, and built-in duplicate protection via logging.
 
-## Features
+---
 
-- Sends a Discord notification when a sale is made on WooCommerce.
-- Customizable order statuses for notifications.
-- Configure different webhook URLs for different order statuses.
-- Color-coded notifications based on order status.
-- Optionally exclude product images from embeds.
+## ✨ Features
 
-## Requirements
+- ✅ Customizable message fields:
+  - Order Status
+  - Payment Info
+  - Product List
+  - Order Date
+  - Billing Info
+  - Transaction ID
+- 🖼️ Optionally disable product image in embed
+- 🎯 Custom webhook & embed color per order status
+- 🔒 Prevent duplicate Discord notifications using internal log tracking
+- ⚙️ Built using native WordPress/WooCommerce APIs
+- 🧠 Compatible with WooCommerce Custom Order Tables (v8+)
+
+---
+
+## 🧰 Requirements
 
 - WordPress 6.2 or higher (tested up to 6.6.2)
-- WooCommerce 8.5 or higher (tested up to 9.3.3)
+- WooCommerce 8.5 or higher (tested up to 10.1.0)
 
-## Installation
+---
 
-1. Download the plugin from the [GitHub repository](https://github.com/Cral-Cactus/wc-sale-discord-notifications).
-2. Upload the plugin files to the `/wp-content/plugins/wc-sale-discord-notifications` directory, or install the plugin through the WordPress plugins screen directly.
-3. Activate the plugin through the 'Plugins' screen in WordPress.
-4. Navigate to WooCommerce > Discord Notifications to configure the plugin.
+## 🔧 Installation
 
-## Configuration
+1. Download this plugin or clone the repo into `/wp-content/plugins/wc-sale-discord-notifications`
+2. Activate the plugin via **Plugins > Installed Plugins**
+3. Navigate to **WooCommerce > Discord Notifications**
+4. Configure your settings
 
-1. **Webhook URL**: Enter the Discord Webhook URL where notifications will be sent.
-2. **Order Status Notifications**: Select the order statuses for which you want to send notifications. You can also specify different webhook URLs and colors for each status.
-3. **Disable Product Image in Embed**: Check this option if you wish to omit product images from the embed.
+---
 
-## Usage
+## ⚙️ Configuration
 
-1. After installing and activating the plugin, go to WooCommerce > Discord Notifications.
-2. Configure your Discord Webhook URL and select the order statuses you want to receive notifications for.
-3. Save your settings.
+1. **Webhook URL**  
+   Enter your Discord Webhook URL (from your Discord server settings)
 
-Whenever an order is placed, a notification will be sent to the specified Discord channel with details about the order.
+2. **Order Status Notifications**  
+   Choose which order statuses should trigger notifications. You can also:
+   - Add different webhook URLs per status
+   - Choose unique embed colors
 
-## Contributing
+3. **Information to Include**  
+   Select which fields should appear in the Discord embed.
 
-1. Fork the repository on GitHub.
-2. Create a new branch for your feature or bug fix.
-3. Commit your changes and push the branch to GitHub.
-4. Open a pull request to the main branch.
+4. **Disable Product Image**  
+   Toggle to prevent product image from appearing in the embed.
 
-## Changelog
+---
+
+## 🔒 Duplicate Protection
+
+To prevent duplicate Discord messages (e.g. when a user refreshes the thank-you page), a local file is used: discord_notification_log.txt
+
+Each entry logs `order_id|event_type`, e.g. `1655 |new`.  
+Before sending a message, the plugin checks if this log already contains that line.  
+If it does, it skips sending.
+
+This ensures each notification is only sent **once per order event**.
+
+---
+
+## 🧪 Development
+
+Built and maintained by:
+
+- [Cral_Cactus](https://github.com/Cral-Cactus)
+- [Dex (ComFoo)](https://github.com/Dextiz)
+
+Pull requests welcome!
+
+---
+
+## 📜 Changelog
+
+### 2.2
+- Implemented per-status duplicate protection using order meta instead of global flag
+- Removed redundant duplicate-check logic and double log writes
+- Added sanitization callbacks for all plugin options to improve data safety
+- Made Discord webhook POST asynchronous (blocking => false) with basic error handling
+- Improved status change hook to only trigger on selected statuses
+- Enhanced embed field building with formatted totals, safe hex color handling, and image fallback
+- Updated “Tested up to” and “WC tested up to” versions
+  
+### 2.1
+- Admin setting: Choose what fields to include in Discord messages
+- Added protection against duplicate notifications using log file
+- Per-status webhook URL
+- Fully compatible with WooCommerce 8+ (custom order tables)
 
 ### 2.0
-- Order status notifications fix and added option to exclude product images from embeds.
+- Added support for excluding product image
 
 ### 1.9
-- Added notifications for changes in order status.
+- Added notifications for changes in order status
 
-### 1.8
-- Major changes.
+### 1.8 and below
+- Initial features and webhook sending
 
-### 1.7
-- Version update.
+---
 
-### 1.6
-- Initial release.
+## 💬 Support
 
-## Author
+Found a bug? Have a suggestion?  
+Open an issue on the [GitHub repo](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues).
 
-[Cral_Cactus](https://github.com/Cral-Cactus)
 
-## Support
-
-If you have any questions or need help, feel free to open an issue on the [GitHub repository](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 - ✅ Customizable message fields:
   - Order Status
   - Payment Info
-  - Product List
+  - Product Lines (names, qty, price)
+  - Product Options (add-ons / Custom fields)
   - Order Date
   - Billing Info
   - Transaction ID
@@ -82,6 +83,10 @@ Pull requests welcome!
 ---
 
 ## 📜 Changelog
+
+### 2.3
+- Add support for custom product fields in Discord notifications
+- New toggle "Custom Fields" in settings, (When enabled, product-level custom fields (from addons/APF) are included in order item details)
 
 ### 2.2
 - Implemented per-status duplicate protection using order meta instead of global flag

--- a/wc-sale-discord-notifications.php
+++ b/wc-sale-discord-notifications.php
@@ -3,14 +3,14 @@
  * Plugin Name: WC Sale Discord Notifications
  * Plugin URI: https://github.com/Cral-Cactus/wc-sale-discord-notifications
  * Description: Sends a notification to a Discord channel when a sale is made or order status changes on WooCommerce. Includes configurable message content and per-status webhooks.
- * Version: 2.2.1
+ * Version: 2.2.2
  * Author: Cral_Cactus + Custom Mod by Dex (product build)
  * Author URI: https://github.com/Cral-Cactus + https://github.com/Dextiz
  * Requires Plugins: woocommerce
  * Requires at least: 6.2
  * Tested up to: 6.8.1
  * WC requires at least: 8.5
- * WC tested up to: 10.1.0
+ * WC tested up to: 9.9.5
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: wc-sale-discord-notifications
@@ -18,32 +18,37 @@
 
 if (!defined('ABSPATH')) exit;
 
-add_action('before_woocommerce_init', function() {
+add_action('before_woocommerce_init', function () {
     if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
         \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
     }
 });
 
-class Sale_Discord_Notifications_Woo {
-
+class Sale_Discord_Notifications_Woo
+{
     const OPTION_GROUP = 'wc_sale_discord_notifications';
     const PAGE_SLUG    = 'wc-sale-discord-notifications';
 
-    public function __construct() {
+    public function __construct()
+    {
         add_action('admin_menu', array($this, 'add_settings_page'));
         add_action('admin_init', array($this, 'register_settings'));
         add_action('admin_enqueue_scripts', array($this, 'enqueue_color_picker'));
+
         add_action('woocommerce_thankyou', array($this, 'send_discord_notification'));
         add_action('woocommerce_order_status_changed', array($this, 'send_discord_notification_on_status_change'), 10, 4);
+
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'plugin_action_links'));
         add_action('plugins_loaded', array($this, 'load_textdomain'));
     }
 
-    public function load_textdomain() {
+    public function load_textdomain()
+    {
         load_plugin_textdomain('wc-sale-discord-notifications', false, dirname(plugin_basename(__FILE__)) . '/languages');
     }
 
-    public function add_settings_page() {
+    public function add_settings_page()
+    {
         add_submenu_page(
             'woocommerce',
             __('Discord Notifications', 'wc-sale-discord-notifications'),
@@ -54,7 +59,8 @@ class Sale_Discord_Notifications_Woo {
         );
     }
 
-    public function register_settings() {
+    public function register_settings()
+    {
         register_setting(self::OPTION_GROUP, 'wc_sale_discord_webhook_url', array(
             'type'              => 'string',
             'sanitize_callback' => 'esc_url_raw',
@@ -64,7 +70,7 @@ class Sale_Discord_Notifications_Woo {
 
         register_setting(self::OPTION_GROUP, 'wc_sale_discord_order_statuses', array(
             'type'              => 'array',
-            'sanitize_callback' => function($val){
+            'sanitize_callback' => function ($val) {
                 $val = is_array($val) ? $val : array();
                 $val = array_map('sanitize_text_field', $val);
                 return array_values(array_filter($val));
@@ -74,7 +80,7 @@ class Sale_Discord_Notifications_Woo {
 
         register_setting(self::OPTION_GROUP, 'wc_sale_discord_status_webhooks', array(
             'type'              => 'array',
-            'sanitize_callback' => function($val){
+            'sanitize_callback' => function ($val) {
                 $out = array();
                 if (is_array($val)) {
                     foreach ($val as $k => $v) {
@@ -88,7 +94,7 @@ class Sale_Discord_Notifications_Woo {
 
         register_setting(self::OPTION_GROUP, 'wc_sale_discord_status_colors', array(
             'type'              => 'array',
-            'sanitize_callback' => function($val){
+            'sanitize_callback' => function ($val) {
                 $out = array();
                 if (is_array($val)) {
                     foreach ($val as $k => $v) {
@@ -101,21 +107,33 @@ class Sale_Discord_Notifications_Woo {
             'default'           => array(),
         ));
 
+        // Robust boolean sanitization (handles 'on', '1', 1, true, 'true')
         register_setting(self::OPTION_GROUP, 'wc_sale_discord_disable_image', array(
             'type'              => 'boolean',
-            'sanitize_callback' => function($v){ return $v ? 1 : 0; },
+            'sanitize_callback' => function ($v) {
+                return ($v === 'on' || $v === '1' || $v === 1 || $v === true || $v === 'true') ? 1 : 0;
+            },
             'default'           => 0,
         ));
 
         register_setting(self::OPTION_GROUP, 'wc_sale_discord_info_fields', array(
             'type'              => 'array',
-            'sanitize_callback' => function($val){
-                $allowed = array('status','payment','product','creation_date','billing','transaction_id');
+            'sanitize_callback' => function ($val) {
+                $allowed = array('status', 'payment', 'product', 'creation_date', 'billing', 'transaction_id');
                 $val = is_array($val) ? $val : array();
                 $val = array_values(array_intersect($val, $allowed));
                 return $val;
             },
             'default'           => array(),
+        ));
+
+        // NEW: Debug toggle to force blocking mode
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_force_blocking', array(
+            'type'              => 'boolean',
+            'sanitize_callback' => function ($v) {
+                return ($v === 'on' || $v === '1' || $v === 1 || $v === true || $v === 'true') ? 1 : 0;
+            },
+            'default'           => 0,
         ));
 
         add_settings_section(
@@ -149,25 +167,41 @@ class Sale_Discord_Notifications_Woo {
             'wc_sale_discord_notifications_section'
         );
 
+        // Hidden + checkbox to ensure unchecked state submits 0
         add_settings_field(
             'wc_sale_discord_disable_image',
             __('Disable product image in embed', 'wc-sale-discord-notifications'),
-            function() {
-                $disable_image = get_option('wc_sale_discord_disable_image');
+            function () {
+                $disable_image = (int) get_option('wc_sale_discord_disable_image', 0);
+                echo '<input type="hidden" name="wc_sale_discord_disable_image" value="0" />';
                 echo '<label><input type="checkbox" name="wc_sale_discord_disable_image" value="1" ' . checked(1, $disable_image, false) . '> ' . esc_html__('Disable image', 'wc-sale-discord-notifications') . '</label>';
+            },
+            self::OPTION_GROUP,
+            'wc_sale_discord_notifications_section'
+        );
+
+        // NEW: Debug toggle field
+        add_settings_field(
+            'wc_sale_discord_force_blocking',
+            __('Debug: Force blocking HTTP requests', 'wc-sale-discord-notifications'),
+            function () {
+                $force = (int) get_option('wc_sale_discord_force_blocking', 0);
+                echo '<input type="hidden" name="wc_sale_discord_force_blocking" value="0" />';
+                echo '<label><input type="checkbox" name="wc_sale_discord_force_blocking" value="1" ' . checked(1, $force, false) . '> ' . esc_html__('Enable for troubleshooting. May slow down checkout.', 'wc-sale-discord-notifications') . '</label>';
             },
             self::OPTION_GROUP,
             'wc_sale_discord_notifications_section'
         );
     }
 
-    public function enqueue_color_picker($hook_suffix) {
+    public function enqueue_color_picker($hook_suffix)
+    {
         if ($hook_suffix !== 'woocommerce_page_' . self::PAGE_SLUG) {
             return;
         }
         wp_enqueue_style('wp-color-picker');
         wp_enqueue_script('wp-color-picker');
-        // Init color pickers on our inputs
+
         $js = "
             (function($){
                 $(function(){
@@ -178,14 +212,16 @@ class Sale_Discord_Notifications_Woo {
         wp_add_inline_script('wp-color-picker', $js);
     }
 
-    public function discord_webhook_url_callback() {
+    public function discord_webhook_url_callback()
+    {
         $webhook_url = get_option('wc_sale_discord_webhook_url', '');
         echo '<input type="url" name="wc_sale_discord_webhook_url" value="' . esc_attr($webhook_url) . '" size="60" placeholder="' . esc_attr__('https://discord.com/api/webhooks/...', 'wc-sale-discord-notifications') . '"/>';
     }
 
-    public function discord_info_fields_callback() {
+    public function discord_info_fields_callback()
+    {
         $options = get_option('wc_sale_discord_info_fields', array());
-        $fields = array(
+        $fields  = array(
             'status'         => __('Status', 'wc-sale-discord-notifications'),
             'payment'        => __('Payment', 'wc-sale-discord-notifications'),
             'product'        => __('Product', 'wc-sale-discord-notifications'),
@@ -194,26 +230,27 @@ class Sale_Discord_Notifications_Woo {
             'transaction_id' => __('Transaction ID', 'wc-sale-discord-notifications'),
         );
         foreach ($fields as $key => $label) {
-            echo '<label style="display:block;margin:2px 0;"><input type="checkbox" name="wc_sale_discord_info_fields[]" value="' . esc_attr($key) . '" ' . checked(in_array($key, (array)$options, true), true, false) . '> ' . esc_html($label) . '</label>';
+            echo '<label style="display:block;margin:2px 0;"><input type="checkbox" name="wc_sale_discord_info_fields[]" value="' . esc_attr($key) . '" ' . checked(in_array($key, (array) $options, true), true, false) . '> ' . esc_html($label) . '</label>';
         }
     }
 
-    public function discord_order_statuses_callback() {
+    public function discord_order_statuses_callback()
+    {
         $order_statuses    = wc_get_order_statuses();
         $selected_statuses = get_option('wc_sale_discord_order_statuses', array());
         $selected_statuses = is_array($selected_statuses) ? $selected_statuses : (array) maybe_unserialize($selected_statuses);
 
-        $status_webhooks   = get_option('wc_sale_discord_status_webhooks', array());
-        $status_colors     = get_option('wc_sale_discord_status_colors', array());
+        $status_webhooks = get_option('wc_sale_discord_status_webhooks', array());
+        $status_colors   = get_option('wc_sale_discord_status_colors', array());
 
         $default_colors = array(
-            'wc-pending'   => '#ffdc00',
-            'wc-processing'=> '#00e5ed',
-            'wc-on-hold'   => '#FFA500',
-            'wc-completed' => '#00d660',
-            'wc-cancelled' => '#d60000',
-            'wc-refunded'  => '#6800e0',
-            'wc-failed'    => '#111111'
+            'wc-pending'    => '#ffdc00',
+            'wc-processing' => '#00e5ed',
+            'wc-on-hold'    => '#FFA500',
+            'wc-completed'  => '#00d660',
+            'wc-cancelled'  => '#d60000',
+            'wc-refunded'   => '#6800e0',
+            'wc-failed'     => '#111111',
         );
 
         foreach ($order_statuses as $status => $label) {
@@ -231,7 +268,8 @@ class Sale_Discord_Notifications_Woo {
         }
     }
 
-    public function notification_settings_page() {
+    public function notification_settings_page()
+    {
         if (!current_user_can('manage_woocommerce')) {
             return;
         }
@@ -244,51 +282,52 @@ class Sale_Discord_Notifications_Woo {
         echo '</form></div>';
     }
 
-    public function send_discord_notification($order_id) {
-    //only send through thank you if it's pending
-    $order = wc_get_order($order_id);
-    if (!$order) return;
+    public function send_discord_notification($order_id)
+    {
+        $order = wc_get_order($order_id);
+        if (!$order) return;
 
-    if ($order->get_status() === 'pending') {
-        $this->send_discord_notification_common($order_id, 'new');
-    }
-}
-
-
-    public function send_discord_notification_on_status_change($order_id, $old_status, $new_status, $order) {
-    $selected = get_option('wc_sale_discord_order_statuses', array());
-    $selected = is_array($selected) ? $selected : (array) maybe_unserialize($selected);
-
-    $target = 'wc-' . $new_status;
-    if (!in_array($target, $selected, true)) {
-        return;
-    }
-
-    // If no previous Discord send for this order, treat this as "new"
-    $any_sent = false;
-    foreach (get_post_meta($order_id) as $key => $val) {
-        if (strpos($key, '_discord_sent_') === 0) {
-            $any_sent = true;
-            break;
+        // Only fire 'new' via thankyou for pending (manual or slow payments)
+        if ($order->get_status() === 'pending') {
+            $this->send_discord_notification_common($order_id, 'new');
         }
     }
 
-    // If we sent a "new" very recently, skip
-    $recent_new_sent = get_post_meta($order_id, '_discord_sent_' . $target . '_new', true);
-    if ($recent_new_sent) {
-        $sent_ts = strtotime($recent_new_sent);
-        if ($sent_ts && ( current_time('timestamp') - $sent_ts ) < 120) {
+    public function send_discord_notification_on_status_change($order_id, $old_status, $new_status, $order)
+    {
+        $selected = get_option('wc_sale_discord_order_statuses', array());
+        $selected = is_array($selected) ? $selected : (array) maybe_unserialize($selected);
+
+        $target = 'wc-' . $new_status;
+        if (!in_array($target, $selected, true)) {
             return;
         }
+
+        // If we recently sent a 'new' for this target status, skip the immediate 'update'
+        $recent_new_sent = get_post_meta($order_id, '_discord_sent_' . $target . '_new', true);
+        if ($recent_new_sent) {
+            $sent_ts = strtotime($recent_new_sent);
+            if ($sent_ts && (current_time('timestamp') - $sent_ts) < 120) {
+                return;
+            }
+        }
+
+        // If no previous Discord send meta exists at all, this is the first notification = 'new'
+        $any_sent = false;
+        $all_meta = get_post_meta($order_id);
+        foreach ($all_meta as $key => $val) {
+            if (strpos($key, '_discord_sent_') === 0) {
+                $any_sent = true;
+                break;
+            }
+        }
+
+        $type = $any_sent ? 'update' : 'new';
+        $this->send_discord_notification_common($order_id, $type);
     }
 
-    $type = $any_sent ? 'update' : 'new';
-    $this->send_discord_notification_common($order_id, $type);
-}
-
-
-
-    private function send_discord_notification_common($order_id, $type) {
+    private function send_discord_notification_common($order_id, $type)
+    {
         $order = wc_get_order($order_id);
         if (!$order) return;
 
@@ -299,10 +338,10 @@ class Sale_Discord_Notifications_Woo {
         $status_colors   = get_option('wc_sale_discord_status_colors', array());
         $enabled_fields  = get_option('wc_sale_discord_info_fields', array());
 
-        $order_status     = 'wc-' . $order->get_status();
+        $order_status = 'wc-' . $order->get_status();
         if (!in_array($order_status, $selected_statuses, true)) return;
 
-        // Statusspecifik spärr per order och typ
+        // Status-specific duplicate protection per order & type
         $status_meta_key = '_discord_sent_' . $order_status . '_' . $type;
         if (get_post_meta($order_id, $status_meta_key, true)) {
             return;
@@ -311,27 +350,27 @@ class Sale_Discord_Notifications_Woo {
         $webhook_url = !empty($status_webhooks[$order_status]) ? $status_webhooks[$order_status] : get_option('wc_sale_discord_webhook_url');
         if (!$webhook_url) return;
 
-        // Färg
-        $hex = !empty($status_colors[$order_status]) ? $status_colors[$order_status] : '#ffffff';
-        $hex = sanitize_hex_color($hex) ?: '#ffffff';
+        // Color
+        $hex         = !empty($status_colors[$order_status]) ? $status_colors[$order_status] : '#ffffff';
+        $hex         = sanitize_hex_color($hex) ?: '#ffffff';
         $embed_color = hexdec(ltrim($hex, '#'));
 
-        // Orderdata
-        $order_data         = $order->get_data();
-        $order_total        = $order_data['total'];
-        $order_currency     = $order_data['currency'];
-        $order_date         = $order_data['date_created'];
-        $order_timestamp    = $order_date ? $order_date->getTimestamp() : time();
-        $payment_method     = !empty($order_data['payment_method_title']) ? $order_data['payment_method_title'] : $order->get_payment_method();
-        $transaction_id     = !empty($order_data['transaction_id']) ? $order_data['transaction_id'] : $order->get_transaction_id();
+        // Order data
+        $order_data      = $order->get_data();
+        $order_currency  = $order_data['currency'];
+        $order_date      = $order_data['date_created'];
+        $order_timestamp = $order_date ? $order_date->getTimestamp() : time();
+
+        $payment_method = !empty($order_data['payment_method_title']) ? $order_data['payment_method_title'] : $order->get_payment_method();
+        $transaction_id = !empty($order_data['transaction_id']) ? $order_data['transaction_id'] : $order->get_transaction_id();
 
         $billing_first_name = $order_data['billing']['first_name'];
         $billing_last_name  = $order_data['billing']['last_name'];
         $billing_email      = $order_data['billing']['email'];
         $billing_discord    = $order->get_meta('_billing_discord');
 
-        $order_items        = $order->get_items();
-        $items_list         = '';
+        $order_items         = $order->get_items();
+        $items_list          = '';
         $first_product_image = '';
 
         foreach ($order_items as $item) {
@@ -342,10 +381,10 @@ class Sale_Discord_Notifications_Woo {
                     $first_product_image = wp_get_attachment_url($img_id);
                 }
             }
-            $product_name   = $item->get_name();
-            $product_qty    = $item->get_quantity();
-            $product_total  = $item->get_total();
-            // Visa radsumma med valuta på ett snyggt sätt utan HTML
+            $product_name  = $item->get_name();
+            $product_qty   = $item->get_quantity();
+            $product_total = $item->get_total();
+
             $line_total_html = wc_price($product_total, array('currency' => $order_currency));
             $line_total      = html_entity_decode(wp_strip_all_tags($line_total_html));
             $items_list     .= "{$product_qty}x {$product_name} - {$line_total}\n";
@@ -354,35 +393,33 @@ class Sale_Discord_Notifications_Woo {
 
         $order_edit_url    = admin_url('post.php?post=' . absint($order_id) . '&action=edit');
         $embed_title       = ($type === 'new') ? '🎉 New Order' : '🪄 Order Update';
-        $order_status_name = ucwords(wc_get_order_status_name($order->get_status()));
+        $order_status_name = wc_get_order_status_name($order->get_status());
 
         $embed_fields   = array();
         $embed_fields[] = array('name' => 'Order ID', 'value' => "[#{$order_id}]({$order_edit_url})", 'inline' => false);
 
-        if (in_array('status', (array)$enabled_fields, true)) {
+        if (in_array('status', (array) $enabled_fields, true)) {
             $embed_fields[] = array('name' => 'Status', 'value' => $order_status_name, 'inline' => false);
         }
-        if (in_array('payment', (array)$enabled_fields, true)) {
-            // Visa totalsumma i samma format som WooCommerce
+        if (in_array('payment', (array) $enabled_fields, true)) {
             $order_total_fmt_html = $order->get_formatted_order_total();
             $order_total_fmt      = html_entity_decode(wp_strip_all_tags($order_total_fmt_html));
-            $embed_fields[] = array('name' => 'Payment', 'value' => "{$order_total_fmt} — {$payment_method}", 'inline' => false);
+            $embed_fields[]       = array('name' => 'Payment', 'value' => "{$order_total_fmt} — {$payment_method}", 'inline' => false);
         }
-        if (in_array('product', (array)$enabled_fields, true)) {
+        if (in_array('product', (array) $enabled_fields, true)) {
             $embed_fields[] = array('name' => 'Product', 'value' => $items_list ? $items_list : '-', 'inline' => false);
         }
-        if (in_array('creation_date', (array)$enabled_fields, true)) {
-            // Discord tidsformat
+        if (in_array('creation_date', (array) $enabled_fields, true)) {
             $embed_fields[] = array('name' => 'Creation Date', 'value' => "<t:{$order_timestamp}:d> (<t:{$order_timestamp}:R>)", 'inline' => false);
         }
-        if (in_array('billing', (array)$enabled_fields, true)) {
+        if (in_array('billing', (array) $enabled_fields, true)) {
             $billing_info = "**Name** » {$billing_first_name} {$billing_last_name}\n**Email** » {$billing_email}";
             if (!empty($billing_discord)) {
                 $billing_info .= "\n**Discord** » {$billing_discord}";
             }
             $embed_fields[] = array('name' => 'Billing Information', 'value' => $billing_info, 'inline' => true);
         }
-        if (in_array('transaction_id', (array)$enabled_fields, true) && !empty($transaction_id)) {
+        if (in_array('transaction_id', (array) $enabled_fields, true) && !empty($transaction_id)) {
             $embed_fields[] = array('name' => 'Transaction ID', 'value' => $transaction_id, 'inline' => false);
         }
 
@@ -399,20 +436,41 @@ class Sale_Discord_Notifications_Woo {
         $this->send_to_discord($webhook_url, $embed, $order_id, $order_status, $type);
     }
 
-    private function send_to_discord($webhook_url, $embed, $order_id = null, $order_status = '', $type = '') {
+    private function send_to_discord($webhook_url, $embed, $order_id = null, $order_status = '', $type = '')
+    {
         $data = wp_json_encode(array('embeds' => array($embed)));
         $args = array(
             'body'     => $data,
             'headers'  => array('Content-Type' => 'application/json'),
             'timeout'  => 20,
-            'blocking' => false,
+            'blocking' => false, // default for performance
         );
+
+        // Debug toggle from settings: force blocking mode for troubleshooting
+        $force_blocking = (int) get_option('wc_sale_discord_force_blocking', 0);
+        if ($force_blocking) {
+            $args['blocking'] = true;
+            $args['timeout']  = max(30, (int) $args['timeout']);
+        }
+
+        // Allow forcing blocking or other args via filter, takes precedence
+        $args = apply_filters('wc_sale_discord_http_args', $args, $order_id, $order_status, $type, $webhook_url);
 
         $response = wp_remote_post($webhook_url, $args);
 
-        // Om du någon gång sätter blocking till true, logga fel här
-        if (is_wp_error($response)) {
-            error_log('[WC Discord] ' . $response->get_error_message());
+        if (!empty($args['blocking'])) {
+            if (is_wp_error($response)) {
+                error_log('[WC Discord] HTTP error: ' . $response->get_error_message());
+            } else {
+                $code = wp_remote_retrieve_response_code($response);
+                if ($code < 200 || $code >= 300) {
+                    error_log('[WC Discord] Non-2xx response: ' . $code . ' Body: ' . wp_remote_retrieve_body($response));
+                }
+            }
+        } else {
+            if (!empty($order_id)) {
+                error_log(sprintf('[WC Discord] Sent async: order=%d status=%s type=%s', (int) $order_id, $order_status, $type));
+            }
         }
 
         if (!empty($order_id) && !empty($order_status) && !empty($type)) {
@@ -421,7 +479,8 @@ class Sale_Discord_Notifications_Woo {
         }
     }
 
-    public function plugin_action_links($links) {
+    public function plugin_action_links($links)
+    {
         $settings_link = '<a href="' . esc_url(admin_url('admin.php?page=' . self::PAGE_SLUG)) . '">' . esc_html__('Settings', 'wc-sale-discord-notifications') . '</a>';
         array_unshift($links, $settings_link);
         return $links;
@@ -429,15 +488,3 @@ class Sale_Discord_Notifications_Woo {
 }
 
 new Sale_Discord_Notifications_Woo();
-
-if (!function_exists('wc_sale_is_wc_order')) {
-    /**
-     * Check if the post is a WooCommerce order.
-     *
-     * @param int $post_id Post id.
-     * @return bool True if the post is a WooCommerce order, false otherwise.
-     */
-    function wc_sale_is_wc_order($post_id = 0) {
-        return ('shop_order' === \Automattic\WooCommerce\Utilities\OrderUtil::get_order_type($post_id));
-    }
-}

--- a/wc-sale-discord-notifications.php
+++ b/wc-sale-discord-notifications.php
@@ -2,17 +2,18 @@
 /**
  * Plugin Name: WC Sale Discord Notifications
  * Plugin URI: https://github.com/Cral-Cactus/wc-sale-discord-notifications
- * Description: Sends a notification to a Discord channel when a sale is made or order status is changed on WooCommerce. Now with configurable message content and duplicate protection.
- * Version: 2.1
- * Author: Cral_Cactus + Custom Mod by Dex
+ * Description: Sends a notification to a Discord channel when a sale is made or order status changes on WooCommerce. Includes configurable message content and per-status webhooks.
+ * Version: 2.2.0
+ * Author: Cral_Cactus + Custom Mod by Dex (product build)
  * Author URI: https://github.com/Cral-Cactus + https://github.com/Dextiz
  * Requires Plugins: woocommerce
  * Requires at least: 6.2
- * Tested up to: 6.6.2
+ * Tested up to: 6.8.1
  * WC requires at least: 8.5
- * WC tested up to: 9.3.3
+ * WC tested up to: 10.1.0
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * Text Domain: wc-sale-discord-notifications
  */
 
 if (!defined('ABSPATH')) exit;
@@ -24,6 +25,10 @@ add_action('before_woocommerce_init', function() {
 });
 
 class Sale_Discord_Notifications_Woo {
+
+    const OPTION_GROUP = 'wc_sale_discord_notifications';
+    const PAGE_SLUG    = 'wc-sale-discord-notifications';
+
     public function __construct() {
         add_action('admin_menu', array($this, 'add_settings_page'));
         add_action('admin_init', array($this, 'register_settings'));
@@ -31,6 +36,11 @@ class Sale_Discord_Notifications_Woo {
         add_action('woocommerce_thankyou', array($this, 'send_discord_notification'));
         add_action('woocommerce_order_status_changed', array($this, 'send_discord_notification_on_status_change'), 10, 4);
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'plugin_action_links'));
+        add_action('plugins_loaded', array($this, 'load_textdomain'));
+    }
+
+    public function load_textdomain() {
+        load_plugin_textdomain('wc-sale-discord-notifications', false, dirname(plugin_basename(__FILE__)) . '/languages');
     }
 
     public function add_settings_page() {
@@ -38,136 +48,198 @@ class Sale_Discord_Notifications_Woo {
             'woocommerce',
             __('Discord Notifications', 'wc-sale-discord-notifications'),
             __('Discord Notifications', 'wc-sale-discord-notifications'),
-            'manage_options',
-            'wc-sale-discord-notifications',
+            'manage_woocommerce',
+            self::PAGE_SLUG,
             array($this, 'notification_settings_page')
         );
     }
 
     public function register_settings() {
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_webhook_url');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_order_statuses');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_webhooks');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_colors');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_disable_image');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_info_fields');
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_webhook_url', array(
+            'type'              => 'string',
+            'sanitize_callback' => 'esc_url_raw',
+            'default'           => '',
+            'show_in_rest'      => false,
+        ));
+
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_order_statuses', array(
+            'type'              => 'array',
+            'sanitize_callback' => function($val){
+                $val = is_array($val) ? $val : array();
+                $val = array_map('sanitize_text_field', $val);
+                return array_values(array_filter($val));
+            },
+            'default'           => array(),
+        ));
+
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_status_webhooks', array(
+            'type'              => 'array',
+            'sanitize_callback' => function($val){
+                $out = array();
+                if (is_array($val)) {
+                    foreach ($val as $k => $v) {
+                        $out[sanitize_text_field($k)] = esc_url_raw($v);
+                    }
+                }
+                return $out;
+            },
+            'default'           => array(),
+        ));
+
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_status_colors', array(
+            'type'              => 'array',
+            'sanitize_callback' => function($val){
+                $out = array();
+                if (is_array($val)) {
+                    foreach ($val as $k => $v) {
+                        $color = sanitize_hex_color($v);
+                        $out[sanitize_text_field($k)] = $color ? $color : '#ffffff';
+                    }
+                }
+                return $out;
+            },
+            'default'           => array(),
+        ));
+
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_disable_image', array(
+            'type'              => 'boolean',
+            'sanitize_callback' => function($v){ return $v ? 1 : 0; },
+            'default'           => 0,
+        ));
+
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_info_fields', array(
+            'type'              => 'array',
+            'sanitize_callback' => function($val){
+                $allowed = array('status','payment','product','creation_date','billing','transaction_id');
+                $val = is_array($val) ? $val : array();
+                $val = array_values(array_intersect($val, $allowed));
+                return $val;
+            },
+            'default'           => array(),
+        ));
 
         add_settings_section(
             'wc_sale_discord_notifications_section',
             __('Discord Webhook Settings', 'wc-sale-discord-notifications'),
             null,
-            'wc_sale_discord_notifications'
+            self::OPTION_GROUP
         );
 
         add_settings_field(
             'wc_sale_discord_webhook_url',
-            __('Discord Webhook URL', 'wc-sale-discord-notifications'),
+            __('Default Discord Webhook URL', 'wc-sale-discord-notifications'),
             array($this, 'discord_webhook_url_callback'),
-            'wc_sale_discord_notifications',
+            self::OPTION_GROUP,
             'wc_sale_discord_notifications_section'
         );
 
         add_settings_field(
             'wc_sale_discord_info_fields',
-            __('Information to Include in Notification', 'wc-sale-discord-notifications'),
+            __('Information to include', 'wc-sale-discord-notifications'),
             array($this, 'discord_info_fields_callback'),
-            'wc_sale_discord_notifications',
+            self::OPTION_GROUP,
             'wc_sale_discord_notifications_section'
         );
 
         add_settings_field(
             'wc_sale_discord_order_statuses',
-            __('Order Status Notifications', 'wc-sale-discord-notifications'),
+            __('Order status notifications', 'wc-sale-discord-notifications'),
             array($this, 'discord_order_statuses_callback'),
-            'wc_sale_discord_notifications',
+            self::OPTION_GROUP,
             'wc_sale_discord_notifications_section'
         );
 
         add_settings_field(
             'wc_sale_discord_disable_image',
-            __('Disable Product Image in Embed', 'wc-sale-discord-notifications'),
+            __('Disable product image in embed', 'wc-sale-discord-notifications'),
             function() {
                 $disable_image = get_option('wc_sale_discord_disable_image');
-                echo '<input type="checkbox" name="wc_sale_discord_disable_image" value="1"' . checked(1, $disable_image, false) . '/>';
+                echo '<label><input type="checkbox" name="wc_sale_discord_disable_image" value="1" ' . checked(1, $disable_image, false) . '> ' . esc_html__('Disable image', 'wc-sale-discord-notifications') . '</label>';
             },
-            'wc_sale_discord_notifications',
+            self::OPTION_GROUP,
             'wc_sale_discord_notifications_section'
         );
     }
 
     public function enqueue_color_picker($hook_suffix) {
+        if ($hook_suffix !== 'woocommerce_page_' . self::PAGE_SLUG) {
+            return;
+        }
         wp_enqueue_style('wp-color-picker');
-        wp_enqueue_script(
-            'wc_sale-color-picker-script',
-            plugins_url('color-picker.js', __FILE__),
-            array('wp-color-picker'),
-            '1.0.0',
-            true
-        );
+        wp_enqueue_script('wp-color-picker');
+        // Init color pickers on our inputs
+        $js = "
+            (function($){
+                $(function(){
+                    $('.discord-embed-color-picker').wpColorPicker();
+                });
+            })(jQuery);
+        ";
+        wp_add_inline_script('wp-color-picker', $js);
     }
 
     public function discord_webhook_url_callback() {
-        $webhook_url = get_option('wc_sale_discord_webhook_url');
-        echo '<input type="text" name="wc_sale_discord_webhook_url" value="' . esc_attr($webhook_url) . '" size="50" />';
+        $webhook_url = get_option('wc_sale_discord_webhook_url', '');
+        echo '<input type="url" name="wc_sale_discord_webhook_url" value="' . esc_attr($webhook_url) . '" size="60" placeholder="' . esc_attr__('https://discord.com/api/webhooks/...', 'wc-sale-discord-notifications') . '"/>';
     }
 
     public function discord_info_fields_callback() {
-        $options = get_option('wc_sale_discord_info_fields', []);
-        $fields = [
-            'status' => 'Status',
-            'payment' => 'Payment',
-            'product' => 'Product',
-            'creation_date' => 'Creation Date',
-            'billing' => 'Billing Information',
-            'transaction_id' => 'Transaction ID'
-        ];
+        $options = get_option('wc_sale_discord_info_fields', array());
+        $fields = array(
+            'status'         => __('Status', 'wc-sale-discord-notifications'),
+            'payment'        => __('Payment', 'wc-sale-discord-notifications'),
+            'product'        => __('Product', 'wc-sale-discord-notifications'),
+            'creation_date'  => __('Creation Date', 'wc-sale-discord-notifications'),
+            'billing'        => __('Billing Information', 'wc-sale-discord-notifications'),
+            'transaction_id' => __('Transaction ID', 'wc-sale-discord-notifications'),
+        );
         foreach ($fields as $key => $label) {
-            $checked = in_array($key, $options) ? 'checked' : '';
-            echo '<label><input type="checkbox" name="wc_sale_discord_info_fields[]" value="' . esc_attr($key) . '" ' . $checked . '> ' . esc_html($label) . '</label><br>';
+            echo '<label style="display:block;margin:2px 0;"><input type="checkbox" name="wc_sale_discord_info_fields[]" value="' . esc_attr($key) . '" ' . checked(in_array($key, (array)$options, true), true, false) . '> ' . esc_html($label) . '</label>';
         }
     }
 
     public function discord_order_statuses_callback() {
-        $order_statuses = wc_get_order_statuses();
-        $selected_statuses = get_option('wc_sale_discord_order_statuses', []);
-        $selected_statuses = maybe_unserialize($selected_statuses);
-        if (!is_array($selected_statuses)) {
-            $selected_statuses = [];
-        }
-        $status_webhooks = get_option('wc_sale_discord_status_webhooks', []);
-        $status_colors = get_option('wc_sale_discord_status_colors', []);
+        $order_statuses    = wc_get_order_statuses();
+        $selected_statuses = get_option('wc_sale_discord_order_statuses', array());
+        $selected_statuses = is_array($selected_statuses) ? $selected_statuses : (array) maybe_unserialize($selected_statuses);
+
+        $status_webhooks   = get_option('wc_sale_discord_status_webhooks', array());
+        $status_colors     = get_option('wc_sale_discord_status_colors', array());
 
         $default_colors = array(
-            'wc-pending' => '#ffdc00',
-            'wc-processing' => '#00e5ed',
-            'wc-on-hold' => '#FFA500',
+            'wc-pending'   => '#ffdc00',
+            'wc-processing'=> '#00e5ed',
+            'wc-on-hold'   => '#FFA500',
             'wc-completed' => '#00d660',
             'wc-cancelled' => '#d60000',
-            'wc-refunded' => '#6800e0',
-            'wc-failed' => '#111111'
+            'wc-refunded'  => '#6800e0',
+            'wc-failed'    => '#111111'
         );
 
         foreach ($order_statuses as $status => $label) {
-            $checked = in_array($status, $selected_statuses) ? 'checked' : '';
-            $webhook = isset($status_webhooks[$status]) ? esc_attr($status_webhooks[$status]) : '';
-            $color = isset($status_colors[$status]) ? esc_attr($status_colors[$status]) : (isset($default_colors[$status]) ? $default_colors[$status] : '#ffffff');
+            $is_checked = in_array($status, $selected_statuses, true);
+            $webhook    = isset($status_webhooks[$status]) ? $status_webhooks[$status] : '';
+            $color      = isset($status_colors[$status]) ? $status_colors[$status] : (isset($default_colors[$status]) ? $default_colors[$status] : '#ffffff');
 
             echo '<p style="margin-bottom: 10px;">';
             echo '<label style="margin-right: 10px;">';
-            echo '<input type="checkbox" name="wc_sale_discord_order_statuses[]" value="' . esc_attr($status) . '" ' . esc_attr($checked) . '> ' . esc_html($label);
-            echo '</label>';
-            echo '<input type="text" class="webhook-input" style="margin-right: 10px" name="wc_sale_discord_status_webhooks[' . esc_attr($status) . ']" value="' . esc_attr($webhook) . '" placeholder="Webhook URL (optional)" size="50">';
+            echo '<input type="checkbox" name="wc_sale_discord_order_statuses[]" value="' . esc_attr($status) . '" ' . checked($is_checked, true, false) . '> ' . esc_html($label);
+            echo '</label> ';
+            echo '<input type="url" class="webhook-input" style="margin-right: 10px" name="wc_sale_discord_status_webhooks[' . esc_attr($status) . ']" value="' . esc_attr($webhook) . '" placeholder="' . esc_attr__('Webhook URL (optional)', 'wc-sale-discord-notifications') . '" size="50"> ';
             echo '<input type="text" name="wc_sale_discord_status_colors[' . esc_attr($status) . ']" value="' . esc_attr($color) . '" class="discord-embed-color-picker" />';
             echo '</p>';
         }
     }
 
     public function notification_settings_page() {
+        if (!current_user_can('manage_woocommerce')) {
+            return;
+        }
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__('Discord Sale Notifications', 'wc-sale-discord-notifications') . '</h1>';
         echo '<form method="post" action="options.php">';
-        settings_fields('wc_sale_discord_notifications');
-        do_settings_sections('wc_sale_discord_notifications');
+        settings_fields(self::OPTION_GROUP);
+        do_settings_sections(self::OPTION_GROUP);
         submit_button();
         echo '</form></div>';
     }
@@ -177,123 +249,149 @@ class Sale_Discord_Notifications_Woo {
     }
 
     public function send_discord_notification_on_status_change($order_id, $old_status, $new_status, $order) {
-        if ($old_status !== 'pending') {
+        $selected = get_option('wc_sale_discord_order_statuses', array());
+        $selected = is_array($selected) ? $selected : (array) maybe_unserialize($selected);
+        $target   = 'wc-' . $new_status;
+        if (in_array($target, $selected, true)) {
             $this->send_discord_notification_common($order_id, 'update');
         }
     }
 
     private function send_discord_notification_common($order_id, $type) {
-        // Check log file to prevent duplicates
-        $log_file = plugin_dir_path(__FILE__) . 'discord_notification_log.txt';
-        $log_entry = "$order_id|$type";
-        if (file_exists($log_file)) {
-            $log_contents = file($log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            if (in_array($log_entry, $log_contents)) {
-                return; // Already sent
-            }
-        }
-
-        $selected_statuses = get_option('wc_sale_discord_order_statuses', []);
-        $selected_statuses = maybe_unserialize($selected_statuses);
-        if (!is_array($selected_statuses)) $selected_statuses = [];
-        $status_webhooks = get_option('wc_sale_discord_status_webhooks', []);
-        $status_colors = get_option('wc_sale_discord_status_colors', []);
-        $enabled_fields = get_option('wc_sale_discord_info_fields', []);
         $order = wc_get_order($order_id);
         if (!$order) return;
 
-        $order_status = 'wc-' . $order->get_status();
-        if (!in_array($order_status, $selected_statuses)) return;
+        $selected_statuses = get_option('wc_sale_discord_order_statuses', array());
+        $selected_statuses = is_array($selected_statuses) ? $selected_statuses : (array) maybe_unserialize($selected_statuses);
+
+        $status_webhooks = get_option('wc_sale_discord_status_webhooks', array());
+        $status_colors   = get_option('wc_sale_discord_status_colors', array());
+        $enabled_fields  = get_option('wc_sale_discord_info_fields', array());
+
+        $order_status     = 'wc-' . $order->get_status();
+        if (!in_array($order_status, $selected_statuses, true)) return;
+
+        // Statusspecifik spärr per order och typ
+        $status_meta_key = '_discord_sent_' . $order_status . '_' . $type;
+        if (get_post_meta($order_id, $status_meta_key, true)) {
+            return;
+        }
+
         $webhook_url = !empty($status_webhooks[$order_status]) ? $status_webhooks[$order_status] : get_option('wc_sale_discord_webhook_url');
-        $embed_color = !empty($status_colors[$order_status]) ? hexdec(substr($status_colors[$order_status], 1)) : hexdec('ffffff');
         if (!$webhook_url) return;
 
-        $order_data = $order->get_data();
-        $order_id = $order_data['id'];
-        $order_status_name = ucwords(wc_get_order_status_name($order->get_status()));
-        $order_total = $order_data['total'];
-        $order_currency = $order_data['currency'];
-        $order_date = $order_data['date_created'];
-        $order_timestamp = $order_date->getTimestamp();
-        $payment_method = $order_data['payment_method_title'];
-        $transaction_id = $order_data['transaction_id'];
-        $billing_first_name = $order_data['billing']['first_name'];
-        $billing_last_name = $order_data['billing']['last_name'];
-        $billing_email = $order_data['billing']['email'];
-        $billing_discord = $order->get_meta('_billing_discord');
+        // Färg
+        $hex = !empty($status_colors[$order_status]) ? $status_colors[$order_status] : '#ffffff';
+        $hex = sanitize_hex_color($hex) ?: '#ffffff';
+        $embed_color = hexdec(ltrim($hex, '#'));
 
-        $order_items = $order->get_items();
-        $items_list = '';
+        // Orderdata
+        $order_data         = $order->get_data();
+        $order_total        = $order_data['total'];
+        $order_currency     = $order_data['currency'];
+        $order_date         = $order_data['date_created'];
+        $order_timestamp    = $order_date ? $order_date->getTimestamp() : time();
+        $payment_method     = !empty($order_data['payment_method_title']) ? $order_data['payment_method_title'] : $order->get_payment_method();
+        $transaction_id     = !empty($order_data['transaction_id']) ? $order_data['transaction_id'] : $order->get_transaction_id();
+
+        $billing_first_name = $order_data['billing']['first_name'];
+        $billing_last_name  = $order_data['billing']['last_name'];
+        $billing_email      = $order_data['billing']['email'];
+        $billing_discord    = $order->get_meta('_billing_discord');
+
+        $order_items        = $order->get_items();
+        $items_list         = '';
         $first_product_image = '';
+
         foreach ($order_items as $item) {
             $product = $item->get_product();
-            if ($first_product_image == '' && $product) {
-                $first_product_image = wp_get_attachment_url($product->get_image_id());
+            if ($first_product_image === '' && $product) {
+                $img_id = $product->get_image_id();
+                if ($img_id) {
+                    $first_product_image = wp_get_attachment_url($img_id);
+                }
             }
-            $items_list .= $item->get_quantity() . 'x ' . $item->get_name() . ' - ' . $item->get_total() . ' ' . $order_currency . "\n";
+            $product_name   = $item->get_name();
+            $product_qty    = $item->get_quantity();
+            $product_total  = $item->get_total();
+            // Visa radsumma med valuta på ett snyggt sätt utan HTML
+            $line_total_html = wc_price($product_total, array('currency' => $order_currency));
+            $line_total      = html_entity_decode(wp_strip_all_tags($line_total_html));
+            $items_list     .= "{$product_qty}x {$product_name} - {$line_total}\n";
         }
+        $items_list = rtrim($items_list, "\n");
 
-        $order_edit_url = admin_url('post.php?post=' . $order_id . '&action=edit');
-        $embed_title = ($type === 'new') ? '🎉 New Order!' : '🪄 Order Update!';
-        $embed_fields = [['name' => 'Order ID', 'value' => "[#{$order_id}]({$order_edit_url})", 'inline' => false]];
+        $order_edit_url    = admin_url('post.php?post=' . absint($order_id) . '&action=edit');
+        $embed_title       = ($type === 'new') ? '🎉 New Order' : '🪄 Order Update';
+        $order_status_name = ucwords(wc_get_order_status_name($order->get_status()));
 
-        if (in_array('status', $enabled_fields)) {
-            $embed_fields[] = ['name' => 'Status', 'value' => $order_status_name, 'inline' => false];
+        $embed_fields   = array();
+        $embed_fields[] = array('name' => 'Order ID', 'value' => "[#{$order_id}]({$order_edit_url})", 'inline' => false);
+
+        if (in_array('status', (array)$enabled_fields, true)) {
+            $embed_fields[] = array('name' => 'Status', 'value' => $order_status_name, 'inline' => false);
         }
-        if (in_array('payment', $enabled_fields)) {
-            $embed_fields[] = ['name' => 'Payment', 'value' => "{$order_total} {$order_currency} - {$payment_method}", 'inline' => false];
+        if (in_array('payment', (array)$enabled_fields, true)) {
+            // Visa totalsumma i samma format som WooCommerce
+            $order_total_fmt_html = $order->get_formatted_order_total();
+            $order_total_fmt      = html_entity_decode(wp_strip_all_tags($order_total_fmt_html));
+            $embed_fields[] = array('name' => 'Payment', 'value' => "{$order_total_fmt} — {$payment_method}", 'inline' => false);
         }
-        if (in_array('product', $enabled_fields)) {
-            $embed_fields[] = ['name' => 'Product', 'value' => rtrim($items_list, "\n"), 'inline' => false];
+        if (in_array('product', (array)$enabled_fields, true)) {
+            $embed_fields[] = array('name' => 'Product', 'value' => $items_list ? $items_list : '-', 'inline' => false);
         }
-        if (in_array('creation_date', $enabled_fields)) {
-            $embed_fields[] = ['name' => 'Creation Date', 'value' => "<t:{$order_timestamp}:d> (<t:{$order_timestamp}:R>)", 'inline' => false];
+        if (in_array('creation_date', (array)$enabled_fields, true)) {
+            // Discord tidsformat
+            $embed_fields[] = array('name' => 'Creation Date', 'value' => "<t:{$order_timestamp}:d> (<t:{$order_timestamp}:R>)", 'inline' => false);
         }
-        if (in_array('billing', $enabled_fields)) {
+        if (in_array('billing', (array)$enabled_fields, true)) {
             $billing_info = "**Name** » {$billing_first_name} {$billing_last_name}\n**Email** » {$billing_email}";
             if (!empty($billing_discord)) {
                 $billing_info .= "\n**Discord** » {$billing_discord}";
             }
-            $embed_fields[] = ['name' => 'Billing Information', 'value' => $billing_info, 'inline' => true];
+            $embed_fields[] = array('name' => 'Billing Information', 'value' => $billing_info, 'inline' => true);
         }
-        if (in_array('transaction_id', $enabled_fields) && !empty($transaction_id)) {
-            $embed_fields[] = ['name' => 'Transaction ID', 'value' => $transaction_id, 'inline' => false];
+        if (in_array('transaction_id', (array)$enabled_fields, true) && !empty($transaction_id)) {
+            $embed_fields[] = array('name' => 'Transaction ID', 'value' => $transaction_id, 'inline' => false);
         }
 
-        $embed = [
-            'title' => $embed_title,
+        $embed = array(
+            'title'  => $embed_title,
             'fields' => $embed_fields,
-            'color' => $embed_color
-        ];
+            'color'  => $embed_color,
+        );
 
         if ($first_product_image && !get_option('wc_sale_discord_disable_image')) {
-            $embed['image'] = ['url' => $first_product_image];
+            $embed['image'] = array('url' => $first_product_image);
         }
 
-        $this->send_to_discord($webhook_url, $embed, $order_id, $type);
+        $this->send_to_discord($webhook_url, $embed, $order_id, $order_status, $type);
     }
 
-    private function send_to_discord($webhook_url, $embed, $order_id = null, $type = null) {
-        $data = wp_json_encode(['embeds' => [$embed]]);
-        $args = [
-            'body' => $data,
-            'headers' => ['Content-Type' => 'application/json'],
-            'timeout' => 60,
-        ];
-        wp_remote_post($webhook_url, $args);
+    private function send_to_discord($webhook_url, $embed, $order_id = null, $order_status = '', $type = '') {
+        $data = wp_json_encode(array('embeds' => array($embed)));
+        $args = array(
+            'body'     => $data,
+            'headers'  => array('Content-Type' => 'application/json'),
+            'timeout'  => 20,
+            'blocking' => false,
+        );
 
-        if (!empty($order_id) && !empty($type)) {
-            $log_file = plugin_dir_path(__FILE__) . 'discord_notification_log.txt';
-            file_put_contents($log_file, "$order_id|$type\n", FILE_APPEND);
+        $response = wp_remote_post($webhook_url, $args);
 
-            if (!metadata_exists('post', $order_id, '_discord_notification_sent')) {
-                update_post_meta($order_id, '_discord_notification_sent', current_time('mysql'));
-            }
+        // Om du någon gång sätter blocking till true, logga fel här
+        if (is_wp_error($response)) {
+            error_log('[WC Discord] ' . $response->get_error_message());
+        }
+
+        if (!empty($order_id) && !empty($order_status) && !empty($type)) {
+            $status_meta_key = '_discord_sent_' . $order_status . '_' . $type;
+            update_post_meta($order_id, $status_meta_key, current_time('mysql'));
         }
     }
 
     public function plugin_action_links($links) {
-        $settings_link = '<a href="' . esc_url(admin_url('admin.php?page=wc-sale-discord-notifications')) . '">' . esc_html__('Settings', 'wc-sale-discord-notifications') . '</a>';
+        $settings_link = '<a href="' . esc_url(admin_url('admin.php?page=' . self::PAGE_SLUG)) . '">' . esc_html__('Settings', 'wc-sale-discord-notifications') . '</a>';
         array_unshift($links, $settings_link);
         return $links;
     }
@@ -302,6 +400,12 @@ class Sale_Discord_Notifications_Woo {
 new Sale_Discord_Notifications_Woo();
 
 if (!function_exists('wc_sale_is_wc_order')) {
+    /**
+     * Check if the post is a WooCommerce order.
+     *
+     * @param int $post_id Post id.
+     * @return bool True if the post is a WooCommerce order, false otherwise.
+     */
     function wc_sale_is_wc_order($post_id = 0) {
         return ('shop_order' === \Automattic\WooCommerce\Utilities\OrderUtil::get_order_type($post_id));
     }


### PR DESCRIPTION
Version 2.1 – Major Feature & Stability Update
This release brings substantial upgrades to the WC Sale Discord Notifications plugin, including requested admin controls and robust safeguards against duplicate notifications.

~~ New Features ~~
* Admin-Controlled Notification Fields You now have full control over what data gets sent to Discord. Choose to include:

✅ Order Status
✅ Payment Info
✅ Product Details
✅ Creation Date
✅ Billing Information
✅ Transaction ID

This gives you granular privacy and clarity based on your business needs.

* Per-Status Customization Assign custom webhook URLs per WooCommerce order status


** New: Duplicate Notification Protection
We’ve solved the infamous “double ping” problem when customers refresh their thank-you page:

✅ A local discord_notification_log.txt is now used to track sent messages by order_id|type

✅ Ensures each order is only notified once per event type (new, update)

✅ Lightweight and file-based — no DB bloat, works with caching setups

🧰 Technical Enhancements
Declares WooCommerce 8+ compatibility with Custom Order Tables

Admin settings organized under WooCommerce > Discord Notifications

Adds settings shortcut link in plugin list

Fully localized and uses WordPress core features (register_setting, get_option, etc.)

🧪 Tested With
WordPress 6.6.2

WooCommerce 9.3.3

PHP 8.x

* File Added discord_notification_log.txt (auto-generated)
(Stores order tracking data to prevent duplicates)