### PR TITLE
Add Initiating payments notification, Order notes embed, and configurable embed fields, more advanced logic on order update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,70 +3,134 @@
 [![GitHub release](https://img.shields.io/github/release/Cral-Cactus/wc-sale-discord-notifications.svg)](https://github.com/Cral-Cactus/wc-sale-discord-notifications/releases)
 [![GitHub issues](https://img.shields.io/github/issues/Cral-Cactus/wc-sale-discord-notifications.svg)](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues/)
 
-This plugin sends a notification to a Discord channel whenever a sale is made on WooCommerce. It is highly customizable, allowing notifications for different order statuses and the ability to configure the webhook URL and message colors.
+> A powerful WooCommerce extension that sends order updates directly to your Discord server. Now with configurable message fields, status-specific webhooks, and built-in duplicate protection via logging.
 
-## Features
+---
 
-- Sends a Discord notification when a sale is made on WooCommerce.
-- Customizable order statuses for notifications.
-- Configure different webhook URLs for different order statuses.
-- Color-coded notifications based on order status.
-- Optionally exclude product images from embeds.
+## ✨ Features
 
-## Requirements
+- ✅ Customizable message fields:
+  - Order Status
+  - Payment Info
+  - Product Lines (names, qty, price)
+  - Product Options (add-ons / Custom fields)
+  - Order Date
+  - Billing Info
+  - Transaction ID
+  - Order Notes
+- 📤 **Initiating Payment** notification – get notified when a customer starts checkout (pending) before payment completes
+- 🖼️ Optionally disable product image in embed
+- 🎯 Custom webhook & embed color per order status
+- 🔒 Prevent duplicate Discord notifications using internal log tracking
+- ⚙️ Built using native WordPress/WooCommerce APIs
+- 🧠 Compatible with WooCommerce Custom Order Tables (v8+)
 
-- WordPress 6.2 or higher (tested up to 6.6.2)
-- WooCommerce 8.5 or higher (tested up to 9.3.3)
+---
 
-## Installation
+## 🧰 Requirements
 
-1. Download the plugin from the [GitHub repository](https://github.com/Cral-Cactus/wc-sale-discord-notifications).
-2. Upload the plugin files to the `/wp-content/plugins/wc-sale-discord-notifications` directory, or install the plugin through the WordPress plugins screen directly.
-3. Activate the plugin through the 'Plugins' screen in WordPress.
-4. Navigate to WooCommerce > Discord Notifications to configure the plugin.
+- WordPress 6.2 or higher (tested up to 6.8.2)
+- WooCommerce 8.5 or higher (tested up to 10.1.2)
 
-## Configuration
+---
 
-1. **Webhook URL**: Enter the Discord Webhook URL where notifications will be sent.
-2. **Order Status Notifications**: Select the order statuses for which you want to send notifications. You can also specify different webhook URLs and colors for each status.
-3. **Disable Product Image in Embed**: Check this option if you wish to omit product images from the embed.
+## 🔧 Installation
 
-## Usage
+1. Download this plugin or clone the repo into `/wp-content/plugins/wc-sale-discord-notifications`
+2. Activate the plugin via **Plugins > Installed Plugins**
+3. Navigate to **WooCommerce > Discord Notifications**
+4. Configure your settings
 
-1. After installing and activating the plugin, go to WooCommerce > Discord Notifications.
-2. Configure your Discord Webhook URL and select the order statuses you want to receive notifications for.
-3. Save your settings.
+---
 
-Whenever an order is placed, a notification will be sent to the specified Discord channel with details about the order.
+## ⚙️ Configuration
 
-## Contributing
+1. **Webhook URL**  
+   Enter your Discord Webhook URL (from your Discord server settings)
 
-1. Fork the repository on GitHub.
-2. Create a new branch for your feature or bug fix.
-3. Commit your changes and push the branch to GitHub.
-4. Open a pull request to the main branch.
+2. **Order Status Notifications**  
+   Choose which order statuses should trigger notifications. You can also:
+   - Add different webhook URLs per status
+   - Choose unique embed colors
 
-## Changelog
+3. **Information to Include**  
+   Select which fields should appear in the Discord embed.
+
+4. **Disable Product Image**  
+   Toggle to prevent product image from appearing in the embed.
+
+5. **Send notification for Initiating payments**  
+   When enabled, sends a distinct "Initiating payment" notification for pending orders. When payment completes, sends "New order" for processing.
+
+---
+
+## 🔒 Duplicate Protection
+
+To prevent duplicate Discord messages (e.g. when a user refreshes the thank-you page), a local file is used: discord_notification_log.txt
+
+Each entry logs `order_id|event_type`, e.g. `1655 |new`.  
+Before sending a message, the plugin checks if this log already contains that line.  
+If it does, it skips sending.
+
+This ensures each notification is only sent **once per order event**.
+
+---
+
+## 🧪 Development
+
+Built and maintained by:
+
+**Author:**
+- [Cral_Cactus](https://github.com/Cral-Cactus)
+
+**Contributors**
+- [Dex (ComFoo)](https://github.com/Dextiz)
+
+Pull requests welcome!
+
+---
+
+## 📜 Changelog
+
+### 3.1
+- Notification for Initiating Payment (when order is placed with pending status, before payment completes)
+- Embedded fields for Order Notes
+- When Initiating Payments is enabled: sends "Initiating payment" for pending orders, then "New order" when payment completes (processing)
+
+### 3.0
+- Updated plugin logo
+
+### 2.3
+- Add support for custom product fields in Discord notifications
+- New toggle "Custom Fields" in settings, (When enabled, product-level custom fields (from addons/APF) are included in order item details)
+
+### 2.2
+- Implemented per-status duplicate protection using order meta instead of global flag
+- Removed redundant duplicate-check logic and double log writes
+- Added sanitization callbacks for all plugin options to improve data safety
+- Made Discord webhook POST asynchronous (blocking => false) with basic error handling
+- Improved status change hook to only trigger on selected statuses
+- Enhanced embed field building with formatted totals, safe hex color handling, and image fallback
+- Updated “Tested up to” and “WC tested up to” versions
+  
+### 2.1
+- Admin setting: Choose what fields to include in Discord messages
+- Added protection against duplicate notifications using log file
+- Per-status webhook URL
+- Fully compatible with WooCommerce 8+ (custom order tables)
 
 ### 2.0
-- Order status notifications fix and added option to exclude product images from embeds.
+- Added support for excluding product image
 
 ### 1.9
-- Added notifications for changes in order status.
+- Added notifications for changes in order status
 
-### 1.8
-- Major changes.
+### 1.8 and below
+- Initial features and webhook sending
 
-### 1.7
-- Version update.
+---
 
-### 1.6
-- Initial release.
+## 💬 Support
 
-## Author
-
-[Cral_Cactus](https://github.com/Cral-Cactus)
-
-## Support
-
-If you have any questions or need help, feel free to open an issue on the [GitHub repository](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues).
+Found a bug? Have a suggestion?  
+Open an issue on the [GitHub repo](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - Billing Info
   - Transaction ID
   - Order Notes
-- ⏳ ** Initiating payment** notification – get notified when a customer begins the payment process (pending)
+- ⏳ Initiating payment notification – get notified when a customer begins the payment process (pending)
 - 🖼️ Optionally disable product image in embed
 - 🎯 Custom webhook & embed color per order status
 - 🔒 Prevent duplicate Discord notifications using internal log tracking

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 
 ## 🔒 Duplicate Protection
 
-To prevent duplicate Discord messages (e.g. when a user refreshes the thank-you page), the plugin stores sent-event metadata on each order (`_discord_sent_*`). Before sending, it checks whether that event was already sent within the last 120 seconds and skips if so.
+To prevent duplicate Discord messages (e.g. when a user refreshes the thank-you page), the plugin stores sent-event metadata on each order (`_discord_sent_*`). Initiating, new, and update notifications all use 120-second time-based deduplication. Before sending, the plugin checks whether that event was already sent within the last 120 seconds and skips if so.
 
 This ensures each notification is only sent **once per order event**.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release](https://img.shields.io/github/release/Cral-Cactus/wc-sale-discord-notifications.svg)](https://github.com/Cral-Cactus/wc-sale-discord-notifications/releases)
 [![GitHub issues](https://img.shields.io/github/issues/Cral-Cactus/wc-sale-discord-notifications.svg)](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues/)
 
-> A powerful WooCommerce extension that sends order updates directly to your Discord server. Now with configurable message fields, status-specific webhooks, and built-in duplicate protection via logging.
+> A powerful WooCommerce extension that sends order updates directly to your Discord server. Configurable message fields, status-specific webhooks, and built-in duplicate protection via order meta.
 
 ---
 
@@ -13,24 +13,27 @@
   - Order Status
   - Payment Info
   - Product Lines (names, qty, price)
-  - Product Options (add-ons / Custom fields)
+  - Product Options (add-ons / custom fields)
   - Order Date
   - Billing Info
   - Transaction ID
-  - Order Notes
-- ⏳ ** Initiating payment** notification – get notified when a customer begins the payment process (pending)
+  - Order Notes (customer and/or internal)
+- ⏳ Initiating payment notification – get notified when a customer begins the payment process (pending)
+- 📝 Customer notes only – optionally exclude internal/admin notes from Order Notes
 - 🖼️ Optionally disable product image in embed
 - 🎯 Custom webhook & embed color per order status
-- 🔒 Prevent duplicate Discord notifications using internal log tracking
+- 🔒 Duplicate protection via order meta (120s deduplication)
+- 📏 Automatic embed size trimming (Discord 6000 char limit)
 - ⚙️ Built using native WordPress/WooCommerce APIs
-- 🧠 Compatible with WooCommerce Custom Order Tables (v8+)
+- 🧠 Compatible with WooCommerce Custom Order Tables (HPOS)
 
 ---
 
 ## 🧰 Requirements
 
-- WordPress 6.2 or higher (tested up to 6.8.2)
-- WooCommerce 8.5 or higher (tested up to 10.1.2)
+- WordPress 6.2 or higher (tested up to 6.9.4)
+- WooCommerce 8.5 or higher (tested up to 10.6.1)
+- PHP 8.0 or higher
 
 ---
 
@@ -46,31 +49,33 @@
 ## ⚙️ Configuration
 
 1. **Webhook URL**  
-   Enter your Discord Webhook URL (from your Discord server settings)
+   Enter your Discord Webhook URL (from your Discord server settings).
 
 2. **Order Status Notifications**  
    Choose which order statuses should trigger notifications. You can also:
    - Add different webhook URLs per status
    - Choose unique embed colors
 
-3. **Information to Include**  
-   Select which fields should appear in the Discord embed.
+3. **Embed Fields**  
+   Select which fields should appear in the Discord embed (status, payment, product, product meta, creation date, billing, transaction ID, order notes).
 
-4. **Disable Product Image**  
+4. **Customer notes only**  
+   When Order Notes is included, show only customer notes (exclude internal/admin notes).
+
+5. **Disable Product Image**  
    Toggle to prevent product image from appearing in the embed.
 
-5. **Send notification for Initiating payments**  
+6. **Send notification for Initiating payments**  
    When enabled, sends a distinct "⏳ Initiating payment" notification for pending orders. When payment completes, sends "🎉 New Order!" for processing.
+
+7. **Debug: Force blocking HTTP requests**  
+   Enable for troubleshooting (may slow down checkout).
 
 ---
 
 ## 🔒 Duplicate Protection
 
-To prevent duplicate Discord messages (e.g. when a user refreshes the thank-you page), a local file is used: discord_notification_log.txt
-
-Each entry logs `order_id|event_type`, e.g. `1655 |new`.  
-Before sending a message, the plugin checks if this log already contains that line.  
-If it does, it skips sending.
+To prevent duplicate Discord messages (e.g. when a user refreshes the thank-you page), the plugin stores sent-event metadata on each order (`_discord_sent_*`). Before sending, it checks whether that event was already sent within the last 120 seconds and skips if so.
 
 This ensures each notification is only sent **once per order event**.
 
@@ -83,7 +88,7 @@ Built and maintained by:
 **Author:**
 - [Cral_Cactus](https://github.com/Cral-Cactus)
 
-**Contributors**
+**Contributors:**
 - [Dex (ComFoo)](https://github.com/Dextiz)
 
 Pull requests welcome!
@@ -91,6 +96,14 @@ Pull requests welcome!
 ---
 
 ## 📜 Changelog
+
+### 3.1.1
+- Customer notes only toggle – exclude internal/admin notes when Order Notes is included
+- Automatic embed size trimming to fit Discord’s 6000 character limit
+- UTF-8 safe truncation for field values (mb_substr when available)
+- Webhook error logging via WooCommerce logger
+- Prefer `WC_Order::get_customer_order_notes()` when available (WC 9.2+)
+- Code quality: docblocks, type hints, removed redundant logic
 
 ### 3.1
 - Notification for Initiating Payment (when order is placed with pending status, before payment completes)
@@ -102,7 +115,7 @@ Pull requests welcome!
 
 ### 2.3
 - Add support for custom product fields in Discord notifications
-- New toggle "Custom Fields" in settings, (When enabled, product-level custom fields (from addons/APF) are included in order item details)
+- New toggle "Custom Fields" in settings (when enabled, product-level custom fields from addons/APF are included in order item details)
 
 ### 2.2
 - Implemented per-status duplicate protection using order meta instead of global flag
@@ -111,11 +124,11 @@ Pull requests welcome!
 - Made Discord webhook POST asynchronous (blocking => false) with basic error handling
 - Improved status change hook to only trigger on selected statuses
 - Enhanced embed field building with formatted totals, safe hex color handling, and image fallback
-- Updated “Tested up to” and “WC tested up to” versions
-  
+- Updated "Tested up to" and "WC tested up to" versions
+
 ### 2.1
 - Admin setting: Choose what fields to include in Discord messages
-- Added protection against duplicate notifications using log file
+- Added protection against duplicate notifications using order meta
 - Per-status webhook URL
 - Fully compatible with WooCommerce 8+ (custom order tables)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - Billing Info
   - Transaction ID
   - Order Notes
-- 📤 **Initiating Payment** notification – get notified when a customer starts checkout (pending) before payment completes
+- ⏳ ** Initiating payment** notification – get notified when a customer begins the payment process (pending)
 - 🖼️ Optionally disable product image in embed
 - 🎯 Custom webhook & embed color per order status
 - 🔒 Prevent duplicate Discord notifications using internal log tracking
@@ -60,7 +60,7 @@
    Toggle to prevent product image from appearing in the embed.
 
 5. **Send notification for Initiating payments**  
-   When enabled, sends a distinct "Initiating payment" notification for pending orders. When payment completes, sends "New order" for processing.
+   When enabled, sends a distinct "⏳ Initiating payment" notification for pending orders. When payment completes, sends "🎉 New Order!" for processing.
 
 ---
 
@@ -95,7 +95,7 @@ Pull requests welcome!
 ### 3.1
 - Notification for Initiating Payment (when order is placed with pending status, before payment completes)
 - Embedded fields for Order Notes
-- When Initiating Payments is enabled: sends "Initiating payment" for pending orders, then "New order" when payment completes (processing)
+- When Initiating Payments is enabled: sends "⏳ Initiating payment" for pending orders, then "🎉 New Order!" when payment completes (processing)
 
 ### 3.0
 - Updated plugin logo

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - 📏 Automatic embed size trimming (Discord 6000 char limit)
 - ⚙️ Built using native WordPress/WooCommerce APIs
 - 🧠 Compatible with WooCommerce Custom Order Tables (HPOS)
+- 📦 Subscription-aware titles when WooCommerce Subscriptions is active (New subscription, Subscription Renewal)
 
 ---
 
@@ -96,6 +97,11 @@ Pull requests welcome!
 ---
 
 ## 📜 Changelog
+
+### 3.1.2
+- Subscription-aware embed titles when WooCommerce Subscriptions is active (New subscription, Subscription Renewal)
+- HTML entity decoding for price display so currency symbols render correctly in Discord (e.g. kr, €, £)
+- Filter `wc_sale_discord_embed_title` for customizing embed titles
 
 ### 3.1.1
 - Customer notes only toggle – exclude internal/admin notes when Order Notes is included

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WC Sale Discord Notifications ===
-Contributors: cralcactus
+Contributors: cralcactus, Dextiz (ComFoo)
 Tags: discord, woocommerce, notifications, sales, orders
 Requires at least: 6.2
 Tested up to: 6.9.4
@@ -24,6 +24,8 @@ This plugin sends a Discord notification for WooCommerce order events. It uses n
   * 📅 Order Date
   * 👤 Billing Info
   * 🔢 Transaction ID
+  * 📜 Order Notes
+
 * 🖼️ Option to disable product image in the embed
 * 🧩 Per-status webhook URL and embed color
 * 🔒 Duplicate-send protection via internal tracking

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ This plugin sends a Discord notification for WooCommerce order events. It uses n
 * Customer notes only toggle – exclude internal/admin notes when Order Notes is included
 * Option to disable product image in the embed
 * Per-status webhook URL and embed color
-* Duplicate-send protection via order meta for the initiating → new order flow (120s window)
+* Duplicate-send protection via order meta (120s deduplication for initiating, new, and update)
 * Automatic embed size trimming for Discord's 6000 character limit
 * Built using native WordPress/WooCommerce APIs
 * Compatible with WooCommerce Custom Order Tables (HPOS)
@@ -74,7 +74,7 @@ This plugin sends a Discord notification for WooCommerce order events. It uses n
 
 == Duplicate Protection ==
 
-To reduce duplicate Discord messages around checkout (for example, if the thank-you page is refreshed), the plugin stores sent-event metadata on each order for the **initiating payment** → **new order** flow. If an initiating payment notification was sent for an order within the last 120 seconds, the plugin will not resend that initiating notification on refresh and may suppress an immediate follow-up "New Order!" notification triggered right after it. Other status-based notifications are sent whenever their configured triggers fire and are not time-deduplicated by this mechanism.
+To prevent duplicate Discord messages (for example, if the thank-you page is refreshed), the plugin stores sent-event metadata on each order (`_discord_sent_*`). Initiating, new, and update notifications all use 120-second time-based deduplication. Before sending, the plugin checks whether that event was already sent within the last 120 seconds and skips if so. This ensures each notification is only sent **once per order event**.
 
 == Usage ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: cralcactus, Dextiz (ComFoo)
 Tags: discord, woocommerce, notifications, sales, orders
 Requires at least: 6.2
 Tested up to: 6.9.4
-Stable tag: 3.1.1
+Stable tag: 3.1.2
 Requires PHP: 8.0
 WC requires at least: 8.5
 WC tested up to: 10.6.1
@@ -36,6 +36,7 @@ This plugin sends a Discord notification for WooCommerce order events. It uses n
 * Automatic embed size trimming for Discord's 6000 character limit
 * Built using native WordPress/WooCommerce APIs
 * Compatible with WooCommerce Custom Order Tables (HPOS)
+* Subscription-aware titles when WooCommerce Subscriptions is active (New subscription, Subscription Renewal)
 
 == Requirements ==
 
@@ -90,6 +91,11 @@ To prevent duplicate Discord messages (for example, if the thank-you page is ref
 
 == Changelog ==
 
+= 3.1.2 =
+* Subscription-aware embed titles when WooCommerce Subscriptions is active (New subscription, Subscription Renewal)
+* HTML entity decoding for price display so currency symbols render correctly in Discord (e.g. kr, €, £)
+* Filter `wc_sale_discord_embed_title` for customizing embed titles
+
 = 3.1.1 =
 * Customer notes only toggle – exclude internal/admin notes when Order Notes is included
 * Automatic embed size trimming to fit Discord's 6000 character limit
@@ -135,6 +141,9 @@ To prevent duplicate Discord messages (for example, if the thank-you page is ref
 * Initial features and webhook sending.
 
 == Upgrade Notice ==
+
+= 3.1.2 =
+Subscription-aware titles, correct currency display in Discord, and embed title filter. Requires PHP 8.0+.
 
 = 3.1.1 =
 Customer notes only toggle, embed size trimming, webhook error logging, and code quality improvements. Requires PHP 8.0+.

--- a/readme.txt
+++ b/readme.txt
@@ -1,79 +1,116 @@
 === WC Sale Discord Notifications ===
 Contributors: cralcactus
-Tags: woocommerce, discord, notifications, sales
+Tags: discord, woocommerce, notifications, sales, orders
 Requires at least: 6.2
-Tested up to: 6.6.2
-Version: 1.9
+Tested up to: 6.9.4
+WC requires at least: 8.5
+WC tested up to: 10.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-This plugin notifies a Discord channel of WooCommerce sales. It supports various order statuses, configurable webhook URLs, and message colors.
+A powerful WooCommerce extension that sends order updates directly to your Discord server. ✨
 
 == Description ==
 
-This plugin sends a notification to a Discord channel whenever a sale is made on WooCommerce. It is highly customizable, allowing notifications for different order statuses and the ability to configure the webhook URL and message colors.
+This plugin sends a Discord notification for WooCommerce order events. It uses native WordPress/WooCommerce APIs and supports WooCommerce Custom Order Tables (v8+). You can choose which order statuses trigger notifications, customize which details are included, set different webhook URLs and embed colors per status, and optionally remove product images from the embed.
 
 == Features ==
 
-* Sends a Discord notification when a sale is made on WooCommerce.
-* Customizable order statuses for notifications.
-* Configure different webhook URLs for different order statuses.
-* Color-coded notifications based on order status.
-* Optionally exclude product images from embeds.
+* ✅ Customizable message fields:
+  * 🏷️ Order Status
+  * 💳 Payment Info
+  * 🛒 Product Lines (names, qty, price)
+  * 🧩 Product Options (add-ons / custom fields)
+  * 📅 Order Date
+  * 👤 Billing Info
+  * 🔢 Transaction ID
+* 🖼️ Option to disable product image in the embed
+* 🧩 Per-status webhook URL and embed color
+* 🔒 Duplicate-send protection via internal tracking
+* ⚙️ Built using native WordPress/WooCommerce APIs
+* 🧠 Compatible with WooCommerce Custom Order Tables (v8+)
 
 == Requirements ==
 
-* WordPress 6.2 or higher (tested up to 6.6.2)
-* WooCommerce 8.5 or higher (tested up to 9.3.3)
+* WordPress 6.2 or higher (tested up to 6.8.2)
+* WooCommerce 8.5 or higher (tested up to 10.1.2)
+* PHP 7.4 or higher
 
 == Installation ==
 
-1. Download the plugin from the [GitHub repository](https://github.com/Cral-Cactus/wc-sale-discord-notifications).
-2. Upload the plugin files to the `/wp-content/plugins/wc-sale-discord-notifications` directory, or install the plugin through the WordPress plugins screen directly.
-3. Activate the plugin through the 'Plugins' screen in WordPress.
-4. Navigate to WooCommerce > Discord Notifications to configure the plugin.
+1. Download this plugin or clone the repo into `/wp-content/plugins/wc-sale-discord-notifications`.
+2. Activate the plugin via **Plugins <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Installed Plugins**.
+3. Go to **WooCommerce <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Discord Notifications**.
+4. Configure your settings.
 
 == Configuration ==
 
-1. **Webhook URL**: Enter the Discord Webhook URL where notifications will be sent.
-2. **Order Status Notifications**: Select the order statuses for which you want to send notifications. You can also specify different webhook URLs and colors for each status.
-3. **Disable Product Image in Embed**: Check this option if you wish to omit product images from the embed.
+1. **Webhook URL**  
+   Enter your Discord Webhook URL (from your Discord server settings).
+
+2. **Order Status Notifications**  
+   Choose which order statuses should trigger notifications. You can also:
+   * Add different webhook URLs per status
+   * Choose unique embed colors
+
+3. **Information to Include**  
+   Select which fields should appear in the Discord embed (status, payment info, items, custom product fields, order date, billing info, transaction ID).
+
+4. **Disable Product Image**  
+   Toggle this to prevent the product image from appearing in the embed.
+
+== Duplicate Protection ==
+
+To prevent duplicate Discord messages (for example, if the thank-you page is refreshed), the plugin keeps track of sent events. Each entry logs `order_id|event_type` (e.g. `1655|new`). Before sending, the plugin checks whether that combination has already been sent and skips if so. This ensures each notification is only sent **once per order event**.
 
 == Usage ==
 
-1. After installing and activating the plugin, go to WooCommerce > Discord Notifications.
-2. Configure your Discord Webhook URL and select the order statuses you want to receive notifications for.
-3. Save your settings.
-
-Whenever an order is placed, a notification will be sent to the specified Discord channel with details about the order.
-
-== Contributing ==
-
-1. Fork the repository on GitHub.
-2. Create a new branch for your feature or bug fix.
-3. Commit your changes and push the branch to GitHub.
-4. Open a pull request to the main branch.
+1. After installing and activating the plugin, go to **WooCommerce <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Discord Notifications**.
+2. Paste your Discord Webhook URL and select which statuses should send notifications.
+3. Choose which fields to include and whether to show product images.
+4. Save your settings.
 
 == Screenshots ==
 
-1. Picture of the plugin dashboard
+1. Settings page under WooCommerce <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Discord Notifications
+2. Image of a completed order Discord webhook
 
 == Changelog ==
+= 3.1 =
+* Implemented notification for Initiating Payment (when order is placed with pending status, before payment completes)
+* Implemented embedded fields for Order Notes
+* When Initiating Payments is enabled: sends "Initiating payment" for pending orders, then "New order" when payment completes (processing)
+
+= 3.0 =
+* Updated plugin logo.
+
+= 2.3 =
+* Added support for custom product fields in Discord notifications.
+* New "Custom Fields" toggle in settings—when enabled, product-level custom fields (from add-ons/APF) are included in order item details.
+
+= 2.2 =
+* Implemented per-status duplicate protection using order meta instead of a global flag.
+* Removed redundant duplicate-check logic and double log writes.
+* Added sanitization callbacks for all plugin options to improve data safety.
+* Made Discord webhook POST asynchronous (`blocking => false`) with basic error handling.
+* Improved status change hook to only trigger on selected statuses.
+* Enhanced embed field building with formatted totals, safe hex color handling, and image fallback.
+* Updated “Tested up to” and “WC tested up to” versions.
+
+= 2.1 =
+* Admin setting to choose what fields to include in Discord messages.
+* Added protection against duplicate notifications using log tracking.
+* Per-status webhook URL support.
+* Full compatibility with WooCommerce 8+ (custom order tables).
 
 = 2.0 =
-* Order status notifications fix and added option to exclude product images from embeds.
+* Added option to exclude product image from embeds.
 
 = 1.9 =
 * Added notifications for changes in order status.
 
-= 1.8 =
-* Major changes.
-
-= 1.7 =
-* Version update.
-
-= 1.6 =
-* Initial release.
+= 1.8 and below =
+* Initial features and webhook sending.
 
 == Author ==
 
@@ -81,4 +118,4 @@ Whenever an order is placed, a notification will be sent to the specified Discor
 
 == Support ==
 
-If you have any questions or need help, feel free to open an issue on the [GitHub repository](https://github.com/Cral-Cactus/wc-sale-discord-notifications).
+Found a bug or have a suggestion? Open an issue on the GitHub repo: [https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues](https://github.com/Cral-Cactus/wc-sale-discord-notifications/issues)

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ This plugin sends a Discord notification for WooCommerce order events. It uses n
 * Customer notes only toggle – exclude internal/admin notes when Order Notes is included
 * Option to disable product image in the embed
 * Per-status webhook URL and embed color
-* Duplicate-send protection via order meta (120s deduplication)
+* Duplicate-send protection via order meta for the initiating → new order flow (120s window)
 * Automatic embed size trimming for Discord's 6000 character limit
 * Built using native WordPress/WooCommerce APIs
 * Compatible with WooCommerce Custom Order Tables (HPOS)
@@ -74,7 +74,7 @@ This plugin sends a Discord notification for WooCommerce order events. It uses n
 
 == Duplicate Protection ==
 
-To prevent duplicate Discord messages (for example, if the thank-you page is refreshed), the plugin stores sent-event metadata on each order. Before sending, it checks whether that event was already sent within the last 120 seconds and skips if so. This ensures each notification is only sent **once per order event**.
+To reduce duplicate Discord messages around checkout (for example, if the thank-you page is refreshed), the plugin stores sent-event metadata on each order for the **initiating payment** → **new order** flow. If an initiating payment notification was sent for an order within the last 120 seconds, the plugin will not resend that initiating notification on refresh and may suppress an immediate follow-up "New Order!" notification triggered right after it. Other status-based notifications are sent whenever their configured triggers fire and are not time-deduplicated by this mechanism.
 
 == Usage ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,46 +3,51 @@ Contributors: cralcactus, Dextiz (ComFoo)
 Tags: discord, woocommerce, notifications, sales, orders
 Requires at least: 6.2
 Tested up to: 6.9.4
+Stable tag: 3.1.1
+Requires PHP: 8.0
 WC requires at least: 8.5
 WC tested up to: 10.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-A powerful WooCommerce extension that sends order updates directly to your Discord server. ✨
+A powerful WooCommerce extension that sends order updates directly to your Discord server.
 
 == Description ==
 
-This plugin sends a Discord notification for WooCommerce order events. It uses native WordPress/WooCommerce APIs and supports WooCommerce Custom Order Tables (v8+). You can choose which order statuses trigger notifications, customize which details are included, set different webhook URLs and embed colors per status, and optionally remove product images from the embed.
+This plugin sends a Discord notification for WooCommerce order events. It uses native WordPress/WooCommerce APIs and supports WooCommerce Custom Order Tables (HPOS). You can choose which order statuses trigger notifications, customize which details are included, set different webhook URLs and embed colors per status, and optionally remove product images from the embed.
 
 == Features ==
 
-* ✅ Customizable message fields:
-  * 🏷️ Order Status
-  * 💳 Payment Info
-  * 🛒 Product Lines (names, qty, price)
-  * 🧩 Product Options (add-ons / custom fields)
-  * 📅 Order Date
-  * 👤 Billing Info
-  * 🔢 Transaction ID
-  * 📜 Order Notes
+* Customizable message fields:
+  * Order Status
+  * Payment Info
+  * Product Lines (names, qty, price)
+  * Product Options (add-ons / custom fields)
+  * Order Date
+  * Billing Info
+  * Transaction ID
+  * Order Notes (customer and/or internal)
 
-* 🖼️ Option to disable product image in the embed
-* 🧩 Per-status webhook URL and embed color
-* 🔒 Duplicate-send protection via internal tracking
-* ⚙️ Built using native WordPress/WooCommerce APIs
-* 🧠 Compatible with WooCommerce Custom Order Tables (v8+)
+* Initiating payment notification when a customer begins checkout (pending)
+* Customer notes only toggle – exclude internal/admin notes when Order Notes is included
+* Option to disable product image in the embed
+* Per-status webhook URL and embed color
+* Duplicate-send protection via order meta (120s deduplication)
+* Automatic embed size trimming for Discord's 6000 character limit
+* Built using native WordPress/WooCommerce APIs
+* Compatible with WooCommerce Custom Order Tables (HPOS)
 
 == Requirements ==
 
-* WordPress 6.2 or higher (tested up to 6.8.2)
-* WooCommerce 8.5 or higher (tested up to 10.1.2)
-* PHP 7.4 or higher
+* WordPress 6.2 or higher (tested up to 6.9.4)
+* WooCommerce 8.5 or higher (tested up to 10.6.1)
+* PHP 8.0 or higher
 
 == Installation ==
 
 1. Download this plugin or clone the repo into `/wp-content/plugins/wc-sale-discord-notifications`.
-2. Activate the plugin via **Plugins <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Installed Plugins**.
-3. Go to **WooCommerce <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Discord Notifications**.
+2. Activate the plugin via **Plugins → Installed Plugins**.
+3. Go to **WooCommerce → Discord Notifications**.
 4. Configure your settings.
 
 == Configuration ==
@@ -55,33 +60,48 @@ This plugin sends a Discord notification for WooCommerce order events. It uses n
    * Add different webhook URLs per status
    * Choose unique embed colors
 
-3. **Information to Include**  
-   Select which fields should appear in the Discord embed (status, payment info, items, custom product fields, order date, billing info, transaction ID).
+3. **Embed Fields**  
+   Select which fields should appear in the Discord embed (status, payment info, items, custom product fields, order date, billing info, transaction ID, order notes).
 
-4. **Disable Product Image**  
+4. **Customer notes only**  
+   When Order Notes is included, show only customer notes (exclude internal/admin notes).
+
+5. **Disable Product Image**  
    Toggle this to prevent the product image from appearing in the embed.
+
+6. **Send notification for Initiating payments**  
+   When enabled, sends "Initiating payment" for pending orders, then "New Order!" when payment completes (processing).
 
 == Duplicate Protection ==
 
-To prevent duplicate Discord messages (for example, if the thank-you page is refreshed), the plugin keeps track of sent events. Each entry logs `order_id|event_type` (e.g. `1655|new`). Before sending, the plugin checks whether that combination has already been sent and skips if so. This ensures each notification is only sent **once per order event**.
+To prevent duplicate Discord messages (for example, if the thank-you page is refreshed), the plugin stores sent-event metadata on each order. Before sending, it checks whether that event was already sent within the last 120 seconds and skips if so. This ensures each notification is only sent **once per order event**.
 
 == Usage ==
 
-1. After installing and activating the plugin, go to **WooCommerce <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Discord Notifications**.
+1. After installing and activating the plugin, go to **WooCommerce → Discord Notifications**.
 2. Paste your Discord Webhook URL and select which statuses should send notifications.
-3. Choose which fields to include and whether to show product images.
+3. Choose which fields to include, whether to show product images, and whether to limit order notes to customer notes only.
 4. Save your settings.
 
 == Screenshots ==
 
-1. Settings page under WooCommerce <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Discord Notifications
+1. Settings page under WooCommerce → Discord Notifications
 2. Image of a completed order Discord webhook
 
 == Changelog ==
+
+= 3.1.1 =
+* Customer notes only toggle – exclude internal/admin notes when Order Notes is included
+* Automatic embed size trimming to fit Discord's 6000 character limit
+* UTF-8 safe truncation for field values (mb_substr when available)
+* Webhook error logging via WooCommerce logger
+* Prefer WC_Order::get_customer_order_notes() when available (WC 9.2+)
+* Code quality: docblocks, type hints, removed redundant logic
+
 = 3.1 =
 * Implemented notification for Initiating Payment (when order is placed with pending status, before payment completes)
 * Implemented embedded fields for Order Notes
-* When Initiating Payments is enabled: sends "Initiating payment" for pending orders, then "New order" when payment completes (processing)
+* When Initiating Payments is enabled: sends "Initiating payment" for pending orders, then "New Order!" when payment completes (processing)
 
 = 3.0 =
 * Updated plugin logo.
@@ -97,11 +117,11 @@ To prevent duplicate Discord messages (for example, if the thank-you page is ref
 * Made Discord webhook POST asynchronous (`blocking => false`) with basic error handling.
 * Improved status change hook to only trigger on selected statuses.
 * Enhanced embed field building with formatted totals, safe hex color handling, and image fallback.
-* Updated “Tested up to” and “WC tested up to” versions.
+* Updated "Tested up to" and "WC tested up to" versions.
 
 = 2.1 =
 * Admin setting to choose what fields to include in Discord messages.
-* Added protection against duplicate notifications using log tracking.
+* Added protection against duplicate notifications using order meta.
 * Per-status webhook URL support.
 * Full compatibility with WooCommerce 8+ (custom order tables).
 
@@ -113,6 +133,11 @@ To prevent duplicate Discord messages (for example, if the thank-you page is ref
 
 = 1.8 and below =
 * Initial features and webhook sending.
+
+== Upgrade Notice ==
+
+= 3.1.1 =
+Customer notes only toggle, embed size trimming, webhook error logging, and code quality improvements. Requires PHP 8.0+.
 
 == Author ==
 

--- a/wc-sale-discord-notifications.php
+++ b/wc-sale-discord-notifications.php
@@ -3,14 +3,14 @@
  * Plugin Name: WC Sale Discord Notifications
  * Plugin URI: https://github.com/Cral-Cactus/wc-sale-discord-notifications
  * Description: Sends a notification to a Discord channel when a sale is made or order status is changed on WooCommerce.
- * Version: 2.0
+ * Version: 3.1
  * Author: Cral_Cactus
  * Author URI: https://github.com/Cral-Cactus
  * Requires Plugins: woocommerce
  * Requires at least: 6.2
- * Tested up to: 6.6.2
+ * Tested up to: 6.9.4
  * WC requires at least: 8.5
- * WC tested up to: 9.3.3
+ * WC tested up to: 10.6.1
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -33,6 +33,8 @@ class Sale_Discord_Notifications_Woo {
         add_action('admin_enqueue_scripts', array($this, 'enqueue_color_picker'));
         add_action('woocommerce_thankyou', array($this, 'send_discord_notification'));
         add_action('woocommerce_order_status_changed', array($this, 'send_discord_notification_on_status_change'), 10, 4);
+        add_action('woocommerce_order_status_pending', array($this, 'send_discord_notification_on_pending'), 10, 2);
+        add_action('woocommerce_checkout_order_processed', array($this, 'send_discord_notification_on_checkout_processed'), 10, 3);
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'plugin_action_links'));
     }
 
@@ -48,11 +50,70 @@ class Sale_Discord_Notifications_Woo {
     }
 
     public function register_settings() {
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_webhook_url');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_order_statuses');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_webhooks');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_colors');
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_disable_image');
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_webhook_url', [
+            'sanitize_callback' => function ($value) {
+                return is_string($value) ? esc_url_raw(trim($value)) : '';
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_order_statuses', [
+            'sanitize_callback' => function ($value) {
+                if (!is_array($value)) {
+                    return [];
+                }
+                return array_map('sanitize_text_field', $value);
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_webhooks', [
+            'sanitize_callback' => function ($value) {
+                if (!is_array($value)) {
+                    return [];
+                }
+                $sanitized = [];
+                foreach ($value as $k => $v) {
+                    $sanitized[sanitize_text_field($k)] = esc_url_raw(trim((string) $v));
+                }
+                return $sanitized;
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_colors', [
+            'sanitize_callback' => function ($value) {
+                if (!is_array($value)) {
+                    return [];
+                }
+                $sanitized = [];
+                foreach ($value as $k => $v) {
+                    $sanitized[sanitize_text_field($k)] = sanitize_hex_color($v) ?: '#ffffff';
+                }
+                return $sanitized;
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_disable_image', [
+            'sanitize_callback' => function ($value) {
+                return !empty($value) ? 1 : 0;
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_include_order_notes', [
+            'sanitize_callback' => function ($value) {
+                return !empty($value) ? 1 : 0;
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_info_fields', [
+            'sanitize_callback' => function ($value) {
+                $allowed = array('status', 'payment', 'product', 'product_meta', 'creation_date', 'billing', 'transaction_id', 'order_notes');
+                $value = is_array($value) ? $value : array();
+                return array_values(array_intersect($value, $allowed));
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_force_blocking', [
+            'sanitize_callback' => function ($value) {
+                return !empty($value) ? 1 : 0;
+            },
+        ]);
+        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_notify_initiating_payment', [
+            'sanitize_callback' => function ($value) {
+                return !empty($value) ? 1 : 0;
+            },
+        ]);
 
         add_settings_section(
             'wc_sale_discord_notifications_section',
@@ -87,6 +148,63 @@ class Sale_Discord_Notifications_Woo {
             'wc_sale_discord_notifications',
             'wc_sale_discord_notifications_section'
         );
+
+        add_settings_field(
+            'wc_sale_discord_notify_initiating_payment',
+            __('Send notification for Initiating payments', 'wc-sale-discord-notifications'),
+            function() {
+                $enabled = (int) get_option('wc_sale_discord_notify_initiating_payment', 0);
+                echo '<input type="checkbox" name="wc_sale_discord_notify_initiating_payment" value="1"' . checked(1, $enabled, false) . '/>';
+                echo '<p class="description">' . esc_html__('Notify when a customer starts checkout (pending) before payment is completed. Uses a separate embed title from completed orders.', 'wc-sale-discord-notifications') . '</p>';
+            },
+            'wc_sale_discord_notifications',
+            'wc_sale_discord_notifications_section'
+        );
+
+        add_settings_field(
+            'wc_sale_discord_info_fields',
+            __('Embed Fields', 'wc-sale-discord-notifications'),
+            array($this, 'info_fields_callback'),
+            'wc_sale_discord_notifications',
+            'wc_sale_discord_notifications_section'
+        );
+
+        add_settings_field(
+            'wc_sale_discord_force_blocking',
+            __('Debug: Force blocking HTTP requests', 'wc-sale-discord-notifications'),
+            function () {
+                $force = (int) get_option('wc_sale_discord_force_blocking', 0);
+                echo '<input type="hidden" name="wc_sale_discord_force_blocking" value="0" />';
+                echo '<label><input type="checkbox" name="wc_sale_discord_force_blocking" value="1" ' . checked(1, $force, false) . '> ' . esc_html__('Enable for troubleshooting. May slow down checkout.', 'wc-sale-discord-notifications') . '</label>';
+            },
+            'wc_sale_discord_notifications',
+            'wc_sale_discord_notifications_section'
+        );
+    }
+
+    public function info_fields_callback() {
+        $info_fields = get_option('wc_sale_discord_info_fields', array());
+        $info_fields = maybe_unserialize($info_fields);
+        if (!is_array($info_fields)) {
+            $info_fields = array();
+        }
+        $available = array(
+            'status'        => __('Status', 'wc-sale-discord-notifications'),
+            'payment'       => __('Payment', 'wc-sale-discord-notifications'),
+            'product'       => __('Product', 'wc-sale-discord-notifications'),
+            'product_meta'  => __('Product Meta', 'wc-sale-discord-notifications'),
+            'creation_date' => __('Creation Date', 'wc-sale-discord-notifications'),
+            'billing'       => __('Billing Information', 'wc-sale-discord-notifications'),
+            'transaction_id' => __('Transaction ID', 'wc-sale-discord-notifications'),
+            'order_notes'   => __('Order Notes', 'wc-sale-discord-notifications'),
+        );
+        echo '<p class="description">' . esc_html__('Choose which fields to include in the Discord embed. Leave empty to include all.', 'wc-sale-discord-notifications') . '</p>';
+        foreach ($available as $key => $label) {
+            $checked = in_array($key, $info_fields) ? 'checked' : '';
+            echo '<p style="margin: 5px 0;">';
+            echo '<label><input type="checkbox" name="wc_sale_discord_info_fields[]" value="' . esc_attr($key) . '" ' . esc_attr($checked) . '> ' . esc_html($label) . '</label>';
+            echo '</p>';
+        }
     }
 
     public function discord_webhook_url_callback() {
@@ -95,14 +213,30 @@ class Sale_Discord_Notifications_Woo {
     }
 
     public function discord_order_statuses_callback() {
+        if (!function_exists('wc_get_order_statuses')) {
+            echo '<p class="description">' . esc_html__('WooCommerce must be active to display order statuses.', 'wc-sale-discord-notifications') . '</p>';
+            return;
+        }
         $order_statuses = wc_get_order_statuses();
+        if (empty($order_statuses)) {
+            echo '<p class="description">' . esc_html__('No order statuses available.', 'wc-sale-discord-notifications') . '</p>';
+            return;
+        }
         $selected_statuses = get_option('wc_sale_discord_order_statuses', []);
         $selected_statuses = maybe_unserialize($selected_statuses);
         if (!is_array($selected_statuses)) {
             $selected_statuses = [];
         }
         $status_webhooks = get_option('wc_sale_discord_status_webhooks', []);
+        $status_webhooks = maybe_unserialize($status_webhooks);
         $status_colors = get_option('wc_sale_discord_status_colors', []);
+        $status_colors = maybe_unserialize($status_colors);
+        if (!is_array($status_webhooks)) {
+            $status_webhooks = [];
+        }
+        if (!is_array($status_colors)) {
+            $status_colors = [];
+        }
 
         $default_colors = array(
             'wc-pending' => '#ffdc00',
@@ -131,6 +265,9 @@ class Sale_Discord_Notifications_Woo {
     }
 
     public function enqueue_color_picker($hook_suffix) {
+        if (strpos($hook_suffix, 'wc-sale-discord-notifications') === false) {
+            return;
+        }
         wp_enqueue_style('wp-color-picker');
         wp_enqueue_script(
             'wc_sale-color-picker-script',
@@ -157,37 +294,131 @@ class Sale_Discord_Notifications_Woo {
     }
 
     public function send_discord_notification($order_id) {
-        $this->send_discord_notification_common($order_id, 'new');
+        $order = wc_get_order($order_id);
+        if (!$order) {
+            return;
+        }
+        // Only fire for pending when customer lands on thank you page (manual/slow payments)
+        if ($order->get_status() === 'pending') {
+            if (get_option('wc_sale_discord_notify_initiating_payment')) {
+                $this->send_discord_notification_common($order_id, 'initiating');
+            } else {
+                $this->send_discord_notification_common($order_id, 'new');
+            }
+        }
     }
 
     public function send_discord_notification_on_status_change($order_id, $old_status, $new_status, $order) {
-        if ($old_status !== 'pending') {
-            $this->send_discord_notification_common($order_id, 'update');
+        $order_obj = is_object($order) ? $order : wc_get_order($order_id);
+
+        // Pending + initiating option enabled: send 'initiating' (bypass selected_statuses)
+        if ($new_status === 'pending' && get_option('wc_sale_discord_notify_initiating_payment')) {
+            $this->maybe_send_initiating_notification($order_id, $order_obj);
+            return;
         }
+
+        $selected = get_option('wc_sale_discord_order_statuses', array());
+        $selected = is_array($selected) ? $selected : (array) maybe_unserialize($selected);
+
+        $target = 'wc-' . $new_status;
+        if (!in_array($target, $selected, true)) {
+            return;
+        }
+
+        // If we recently sent a 'new' for this target status, skip the immediate 'update'
+        $recent_new_sent = $order_obj ? $order_obj->get_meta('_discord_sent_' . $target . '_new') : '';
+        if ($recent_new_sent) {
+            $sent_ts = strtotime($recent_new_sent);
+            if ($sent_ts && (current_time('timestamp') - $sent_ts) < 120) {
+                return;
+            }
+        }
+
+        // First notification for a completed status becomes 'new'. Exclude _initiating so pending→processing sends "New Order".
+        $any_sent = false;
+        if ($order_obj) {
+            $meta_data = $order_obj->get_meta_data();
+            foreach ($meta_data as $meta) {
+                $key = is_object($meta) && method_exists($meta, 'get_key') ? $meta->get_key() : (isset($meta->key) ? $meta->key : '');
+                if (strpos($key, '_discord_sent_') === 0 && strpos($key, '_initiating') === false) {
+                    $any_sent = true;
+                    break;
+                }
+            }
+        }
+
+        $type = $any_sent ? 'update' : 'new';
+        $this->send_discord_notification_common($order_id, $type);
+    }
+
+    /**
+     * Handle orders created directly with pending status (admin, API) when woocommerce_order_status_changed may not fire.
+     */
+    public function send_discord_notification_on_pending($order_id, $order = null) {
+        $this->maybe_send_initiating_notification($order_id, $order);
+    }
+
+    /**
+     * Backup trigger: fires when checkout order is processed. Catches pending orders when status hooks
+     * may not fire (e.g. block checkout, some payment gateways).
+     */
+    public function send_discord_notification_on_checkout_processed($order_id, $posted_data, $order) {
+        $this->maybe_send_initiating_notification($order_id, $order);
+    }
+
+    /**
+     * Send initiating payment notification if conditions are met. Deduplicated via 120s meta check.
+     */
+    private function maybe_send_initiating_notification($order_id, $order = null) {
+        if (!get_option('wc_sale_discord_notify_initiating_payment')) {
+            return;
+        }
+        $order_obj = is_object($order) ? $order : wc_get_order($order_id);
+        if (!$order_obj || $order_obj->get_status() !== 'pending') {
+            return;
+        }
+        $recent_initiating_sent = $order_obj->get_meta('_discord_sent_wc-pending_initiating');
+        if ($recent_initiating_sent) {
+            $sent_ts = strtotime($recent_initiating_sent);
+            if ($sent_ts && (current_time('timestamp') - $sent_ts) < 120) {
+                return;
+            }
+        }
+        $this->send_discord_notification_common($order_id, 'initiating');
     }
 
     private function send_discord_notification_common($order_id, $type) {
-        $selected_statuses = get_option('wc_sale_discord_order_statuses', []);
-        $selected_statuses = maybe_unserialize($selected_statuses);
-        if (!is_array($selected_statuses)) {
-            $selected_statuses = [];
-        }
-        $status_webhooks = get_option('wc_sale_discord_status_webhooks', []);
-        $status_colors = get_option('wc_sale_discord_status_colors', []);
         $order = wc_get_order($order_id);
 
         if (!$order) {
             return;
         }
 
-        $order_status = 'wc-' . $order->get_status();
-
-        if (!in_array($order_status, $selected_statuses)) {
-            return;
+        $order_status_key = 'wc-' . $order->get_status();
+        $status_webhooks = maybe_unserialize(get_option('wc_sale_discord_status_webhooks', []));
+        $status_colors = maybe_unserialize(get_option('wc_sale_discord_status_colors', []));
+        if (!is_array($status_webhooks)) {
+            $status_webhooks = [];
+        }
+        if (!is_array($status_colors)) {
+            $status_colors = [];
         }
 
-        $webhook_url = !empty($status_webhooks[$order_status]) ? $status_webhooks[$order_status] : get_option('wc_sale_discord_webhook_url');
-        $embed_color = !empty($status_colors[$order_status]) ? hexdec(substr($status_colors[$order_status], 1)) : hexdec(substr('#ffffff', 1));
+        $is_initiating = ($type === 'initiating');
+
+        if (!$is_initiating) {
+            $selected_statuses = get_option('wc_sale_discord_order_statuses', []);
+            $selected_statuses = maybe_unserialize($selected_statuses);
+            if (!is_array($selected_statuses)) {
+                $selected_statuses = [];
+            }
+            if (!in_array($order_status_key, $selected_statuses)) {
+                return;
+            }
+        }
+
+        $webhook_url = !empty($status_webhooks[$order_status_key]) ? $status_webhooks[$order_status_key] : get_option('wc_sale_discord_webhook_url');
+        $embed_color = !empty($status_colors[$order_status_key]) ? hexdec(substr($status_colors[$order_status_key], 1)) : hexdec(substr('#ffdc00', 1));
 
         if (!$webhook_url) {
             return;
@@ -196,7 +427,7 @@ class Sale_Discord_Notifications_Woo {
         $order_data = $order->get_data();
         $order_id = $order_data['id'];
         $order_status = ucwords(wc_get_order_status_name($order->get_status()));
-        $order_total = $order_data['total'];
+        $order_total = (string) round((float) $order_data['total'], 0);
         $order_currency = $order_data['currency'];
         $order_date = $order_data['date_created'];
         $order_timestamp = $order_date->getTimestamp();
@@ -220,33 +451,62 @@ class Sale_Discord_Notifications_Woo {
 
             $product_name = $item->get_name();
             $product_quantity = $item->get_quantity();
-            $product_total = $item->get_total();
+            $product_total = (string) round((float) $item->get_total(), 0);
             $items_list .= "{$product_quantity}x {$product_name} - {$product_total} {$order_currency}\n";
         }
         $items_list = rtrim($items_list, "\n");
 
         $order_edit_url = admin_url('post.php?post=' . $order_id . '&action=edit');
 
-        $embed_title = ($type === 'new') ? '🎉 New Order!' : '🪄 Order Update!';
+        $info_fields = get_option('wc_sale_discord_info_fields', array());
+        $info_fields = maybe_unserialize($info_fields);
+        if (!is_array($info_fields)) {
+            $info_fields = array();
+        }
+        $use_info_fields = !empty($info_fields);
+        $field_included = function ($key) use ($use_info_fields, $info_fields) {
+            return !$use_info_fields || in_array($key, $info_fields, true);
+        };
 
-        $embed = [
-            'title' => $embed_title,
-            'fields' => [
-                ['name' => 'Order ID', 'value' => "[#{$order_id}]({$order_edit_url})", 'inline' => false],
-                ['name' => 'Status', 'value' => $order_status, 'inline' => false],
-                ['name' => 'Payment', 'value' => "{$order_total} {$order_currency} - {$payment_method}", 'inline' => false],
-                ['name' => 'Product', 'value' => $items_list, 'inline' => false],
-                ['name' => 'Creation Date', 'value' => "<t:{$order_timestamp}:d> (<t:{$order_timestamp}:R>)", 'inline' => false],
-                ['name' => 'Billing Information', 'value' => "**Name** » {$billing_first_name} {$billing_last_name}\n**Email** » {$billing_email}", 'inline' => true]
-            ],
-            'color' => $embed_color
+        $embed_title = ($type === 'initiating') ? '⏳ Initiating payment' : (($type === 'new') ? '🎉 New Order!' : '🪄 Order Update!');
+
+        $embed_fields = [
+            ['name' => 'Order ID', 'value' => "[#{$order_id}]({$order_edit_url})", 'inline' => false],
         ];
-		
-        if (!empty($billing_discord)) {
-            $embed['fields'][count($embed['fields']) - 1]['value'] .= "\n**Discord** » {$billing_discord}";
+
+        if ($field_included('status')) {
+            $embed_fields[] = ['name' => 'Status', 'value' => $order_status, 'inline' => false];
+        }
+        if ($field_included('payment')) {
+            $embed_fields[] = ['name' => 'Payment', 'value' => "{$order_total} {$order_currency} - {$payment_method}", 'inline' => false];
+        }
+        if ($field_included('product')) {
+            $embed_fields[] = ['name' => 'Product', 'value' => $items_list, 'inline' => false];
+        }
+        if ($field_included('product_meta')) {
+            $product_meta_list = $this->get_product_meta_for_embed($order_items);
+            if (!empty($product_meta_list)) {
+                $embed_fields[] = ['name' => 'Product Meta', 'value' => $product_meta_list, 'inline' => false];
+            }
+        }
+        if ($field_included('creation_date')) {
+            $embed_fields[] = ['name' => 'Creation Date', 'value' => "<t:{$order_timestamp}:d> (<t:{$order_timestamp}:R>)", 'inline' => false];
+        }
+        if ($field_included('billing')) {
+            $billing_value = "**Name** » {$billing_first_name} {$billing_last_name}\n**Email** » {$billing_email}";
+            if (!empty($billing_discord)) {
+                $billing_value .= "\n**Discord** » {$billing_discord}";
+            }
+            $embed_fields[] = ['name' => 'Billing Information', 'value' => $billing_value, 'inline' => true];
         }
 
-        if (!empty($transaction_id)) {
+        $embed = [
+            'title'  => $embed_title,
+            'fields' => $embed_fields,
+            'color'  => $embed_color
+        ];
+
+        if ($field_included('transaction_id') && !empty($transaction_id)) {
             $embed['fields'][] = ['name' => 'Transaction ID', 'value' => $transaction_id, 'inline' => false];
         }
 
@@ -254,7 +514,102 @@ class Sale_Discord_Notifications_Woo {
             $embed['image'] = ['url' => $first_product_image];
         }
 
+        $include_order_notes = get_option('wc_sale_discord_include_order_notes') || $field_included('order_notes');
+        if ($include_order_notes) {
+            $order_notes = $this->get_order_notes_for_embed($order_id);
+            if (!empty($order_notes)) {
+                $embed['fields'][] = ['name' => 'Order Notes', 'value' => $order_notes, 'inline' => false];
+            }
+        }
+
         $this->send_to_discord($webhook_url, $embed);
+
+        // Track sent notifications for double-notification failsafe
+        if ($type === 'new' && $order) {
+            $order->update_meta_data('_discord_sent_' . $order_status_key . '_new', current_time('mysql'));
+            $order->save();
+        }
+        if ($type === 'initiating' && $order) {
+            $order->update_meta_data('_discord_sent_wc-pending_initiating', current_time('mysql'));
+            $order->save();
+        }
+    }
+
+    /**
+     * Get formatted order notes for Discord embed.
+     * Discord embed field values have a 1024 character limit.
+     *
+     * @param int $order_id Order ID.
+     * @return string Formatted order notes or empty string.
+     */
+    private function get_order_notes_for_embed(int $order_id): string {
+        if (!function_exists('wc_get_order_notes')) {
+            return '';
+        }
+
+        $notes = wc_get_order_notes([
+            'order_id' => $order_id,
+            'limit'    => 20,
+            'orderby'  => 'date_created',
+            'order'    => 'DESC',
+        ]);
+
+        if (empty($notes)) {
+            return '';
+        }
+
+        $lines = [];
+        $max_length = 950; // Leave room for truncation message
+        $current_length = 0;
+
+        foreach ($notes as $note) {
+            $type = (is_object($note) && method_exists($note, 'get_type')) ? $note->get_type() : (isset($note->type) ? $note->type : 'internal');
+            $type_label = ('customer' === $type) ? __('Customer', 'wc-sale-discord-notifications') : __('Internal', 'wc-sale-discord-notifications');
+            $content = (is_object($note) && method_exists($note, 'get_content')) ? $note->get_content() : (isset($note->content) ? $note->content : '');
+            $content = wp_strip_all_tags($content);
+
+            $date_obj = (is_object($note) && method_exists($note, 'get_date_created')) ? $note->get_date_created() : (isset($note->date_created) ? $note->date_created : null);
+            $date = $date_obj && method_exists($date_obj, 'format') ? $date_obj->format('Y-m-d H:i') : '';
+
+            if (empty($content)) {
+                continue;
+            }
+
+            $line = "**{$type_label}** ({$date}): {$content}";
+            if ($current_length + strlen($line) + 2 > $max_length) {
+                $lines[] = '…';
+                break;
+            }
+            $lines[] = $line;
+            $current_length += strlen($line) + 2;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Get formatted product/item meta for Discord embed.
+     *
+     * @param array $order_items Order items from WC_Order::get_items().
+     * @return string Formatted product meta or empty string.
+     */
+    private function get_product_meta_for_embed($order_items): string {
+        $lines = [];
+        foreach ($order_items as $item) {
+            $meta_data = $item->get_formatted_meta_data('', true);
+            if (empty($meta_data)) {
+                continue;
+            }
+            $item_name = $item->get_name();
+            foreach ($meta_data as $meta) {
+                $key = isset($meta->display_key) ? $meta->display_key : '';
+                $val = isset($meta->display_value) ? wp_strip_all_tags($meta->display_value) : '';
+                if ($key !== '') {
+                    $lines[] = "**{$item_name}**: {$key} » {$val}";
+                }
+            }
+        }
+        return implode("\n", $lines);
     }
 
     private function send_to_discord($webhook_url, $embed) {
@@ -265,6 +620,10 @@ class Sale_Discord_Notifications_Woo {
             'headers' => ['Content-Type' => 'application/json'],
             'timeout' => 60,
         ];
+
+        if (get_option('wc_sale_discord_force_blocking')) {
+            $args['blocking'] = true;
+        }
 
         wp_remote_post($webhook_url, $args);
     }

--- a/wc-sale-discord-notifications.php
+++ b/wc-sale-discord-notifications.php
@@ -3,7 +3,7 @@
  * Plugin Name: WC Sale Discord Notifications
  * Plugin URI: https://github.com/Cral-Cactus/wc-sale-discord-notifications
  * Description: Sends a notification to a Discord channel when a sale is made or order status is changed on WooCommerce.
- * Version: 3.1
+ * Version: 3.1.1
  * Author: Cral_Cactus
  * Author URI: https://github.com/Cral-Cactus
  * Requires Plugins: woocommerce
@@ -27,6 +27,11 @@ add_action('before_woocommerce_init', function(){
 
 class Sale_Discord_Notifications_Woo {
 
+    const OPTION_GROUP = 'wc_sale_discord_notifications';
+    const PAGE_SLUG = 'wc-sale-discord-notifications';
+    const DISCORD_FIELD_MAX = 1024;
+    const DISCORD_EMBED_MAX = 6000;
+
     public function __construct() {
         add_action('admin_menu', array($this, 'add_settings_page'));
         add_action('admin_init', array($this, 'register_settings'));
@@ -44,18 +49,18 @@ class Sale_Discord_Notifications_Woo {
             __('Discord Notifications', 'wc-sale-discord-notifications'),
             __('Discord Notifications', 'wc-sale-discord-notifications'),
             'manage_options',
-            'wc-sale-discord-notifications',
+            self::PAGE_SLUG,
             array($this, 'notification_settings_page')
         );
     }
 
     public function register_settings() {
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_webhook_url', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_webhook_url', [
             'sanitize_callback' => function ($value) {
                 return is_string($value) ? esc_url_raw(trim($value)) : '';
             },
         ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_order_statuses', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_order_statuses', [
             'sanitize_callback' => function ($value) {
                 if (!is_array($value)) {
                     return [];
@@ -63,7 +68,7 @@ class Sale_Discord_Notifications_Woo {
                 return array_map('sanitize_text_field', $value);
             },
         ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_webhooks', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_status_webhooks', [
             'sanitize_callback' => function ($value) {
                 if (!is_array($value)) {
                     return [];
@@ -75,7 +80,7 @@ class Sale_Discord_Notifications_Woo {
                 return $sanitized;
             },
         ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_status_colors', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_status_colors', [
             'sanitize_callback' => function ($value) {
                 if (!is_array($value)) {
                     return [];
@@ -87,55 +92,55 @@ class Sale_Discord_Notifications_Woo {
                 return $sanitized;
             },
         ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_disable_image', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_disable_image', [
             'sanitize_callback' => function ($value) {
                 return !empty($value) ? 1 : 0;
             },
         ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_include_order_notes', [
-            'sanitize_callback' => function ($value) {
-                return !empty($value) ? 1 : 0;
-            },
-        ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_info_fields', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_info_fields', [
             'sanitize_callback' => function ($value) {
                 $allowed = array('status', 'payment', 'product', 'product_meta', 'creation_date', 'billing', 'transaction_id', 'order_notes');
                 $value = is_array($value) ? $value : array();
                 return array_values(array_intersect($value, $allowed));
             },
         ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_force_blocking', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_force_blocking', [
             'sanitize_callback' => function ($value) {
                 return !empty($value) ? 1 : 0;
             },
         ]);
-        register_setting('wc_sale_discord_notifications', 'wc_sale_discord_notify_initiating_payment', [
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_notify_initiating_payment', [
+            'sanitize_callback' => function ($value) {
+                return !empty($value) ? 1 : 0;
+            },
+        ]);
+        register_setting(self::OPTION_GROUP, 'wc_sale_discord_order_notes_customer_only', [
             'sanitize_callback' => function ($value) {
                 return !empty($value) ? 1 : 0;
             },
         ]);
 
         add_settings_section(
-            'wc_sale_discord_notifications_section',
+            self::OPTION_GROUP . '_section',
             __('Discord Webhook Settings', 'wc-sale-discord-notifications'),
             null,
-            'wc_sale_discord_notifications'
+            self::OPTION_GROUP
         );
 
         add_settings_field(
             'wc_sale_discord_webhook_url',
             __('Discord Webhook URL', 'wc-sale-discord-notifications'),
             array($this, 'discord_webhook_url_callback'),
-            'wc_sale_discord_notifications',
-            'wc_sale_discord_notifications_section'
+            self::OPTION_GROUP,
+            self::OPTION_GROUP . '_section'
         );
 
         add_settings_field(
             'wc_sale_discord_order_statuses',
             __('Order Status Notifications', 'wc-sale-discord-notifications'),
             array($this, 'discord_order_statuses_callback'),
-            'wc_sale_discord_notifications',
-            'wc_sale_discord_notifications_section'
+            self::OPTION_GROUP,
+            self::OPTION_GROUP . '_section'
         );
 
         add_settings_field(
@@ -145,8 +150,8 @@ class Sale_Discord_Notifications_Woo {
                 $disable_image = get_option('wc_sale_discord_disable_image');
                 echo '<input type="checkbox" name="wc_sale_discord_disable_image" value="1"' . checked(1, $disable_image, false) . '/>';
             },
-            'wc_sale_discord_notifications',
-            'wc_sale_discord_notifications_section'
+            self::OPTION_GROUP,
+            self::OPTION_GROUP . '_section'
         );
 
         add_settings_field(
@@ -157,16 +162,28 @@ class Sale_Discord_Notifications_Woo {
                 echo '<input type="checkbox" name="wc_sale_discord_notify_initiating_payment" value="1"' . checked(1, $enabled, false) . '/>';
                 echo '<p class="description">' . esc_html__('Notify when a customer starts checkout (pending) before payment is completed. Uses a separate embed title from completed orders.', 'wc-sale-discord-notifications') . '</p>';
             },
-            'wc_sale_discord_notifications',
-            'wc_sale_discord_notifications_section'
+            self::OPTION_GROUP,
+            self::OPTION_GROUP . '_section'
         );
 
         add_settings_field(
             'wc_sale_discord_info_fields',
             __('Embed Fields', 'wc-sale-discord-notifications'),
             array($this, 'info_fields_callback'),
-            'wc_sale_discord_notifications',
-            'wc_sale_discord_notifications_section'
+            self::OPTION_GROUP,
+            self::OPTION_GROUP . '_section'
+        );
+
+        add_settings_field(
+            'wc_sale_discord_order_notes_customer_only',
+            __('Customer notes only', 'wc-sale-discord-notifications'),
+            function () {
+                $customer_only = (int) get_option('wc_sale_discord_order_notes_customer_only', 0);
+                echo '<input type="checkbox" name="wc_sale_discord_order_notes_customer_only" value="1"' . checked(1, $customer_only, false) . '/>';
+                echo '<p class="description">' . esc_html__('When Order Notes is included, show only customer notes (exclude internal/admin notes).', 'wc-sale-discord-notifications') . '</p>';
+            },
+            self::OPTION_GROUP,
+            self::OPTION_GROUP . '_section'
         );
 
         add_settings_field(
@@ -177,14 +194,13 @@ class Sale_Discord_Notifications_Woo {
                 echo '<input type="hidden" name="wc_sale_discord_force_blocking" value="0" />';
                 echo '<label><input type="checkbox" name="wc_sale_discord_force_blocking" value="1" ' . checked(1, $force, false) . '> ' . esc_html__('Enable for troubleshooting. May slow down checkout.', 'wc-sale-discord-notifications') . '</label>';
             },
-            'wc_sale_discord_notifications',
-            'wc_sale_discord_notifications_section'
+            self::OPTION_GROUP,
+            self::OPTION_GROUP . '_section'
         );
     }
 
     public function info_fields_callback() {
         $info_fields = get_option('wc_sale_discord_info_fields', array());
-        $info_fields = maybe_unserialize($info_fields);
         if (!is_array($info_fields)) {
             $info_fields = array();
         }
@@ -223,14 +239,11 @@ class Sale_Discord_Notifications_Woo {
             return;
         }
         $selected_statuses = get_option('wc_sale_discord_order_statuses', []);
-        $selected_statuses = maybe_unserialize($selected_statuses);
         if (!is_array($selected_statuses)) {
             $selected_statuses = [];
         }
         $status_webhooks = get_option('wc_sale_discord_status_webhooks', []);
-        $status_webhooks = maybe_unserialize($status_webhooks);
         $status_colors = get_option('wc_sale_discord_status_colors', []);
-        $status_colors = maybe_unserialize($status_colors);
         if (!is_array($status_webhooks)) {
             $status_webhooks = [];
         }
@@ -265,7 +278,7 @@ class Sale_Discord_Notifications_Woo {
     }
 
     public function enqueue_color_picker($hook_suffix) {
-        if (strpos($hook_suffix, 'wc-sale-discord-notifications') === false) {
+        if (strpos($hook_suffix, self::PAGE_SLUG) === false) {
             return;
         }
         wp_enqueue_style('wp-color-picker');
@@ -284,8 +297,8 @@ class Sale_Discord_Notifications_Woo {
             <h1><?php esc_html_e('Discord Sale Notifications', 'wc-sale-discord-notifications'); ?></h1>
             <form method="post" action="options.php">
                 <?php
-                settings_fields('wc_sale_discord_notifications');
-                do_settings_sections('wc_sale_discord_notifications');
+                settings_fields(self::OPTION_GROUP);
+                do_settings_sections(self::OPTION_GROUP);
                 submit_button();
                 ?>
             </form>
@@ -293,6 +306,9 @@ class Sale_Discord_Notifications_Woo {
         <?php
     }
 
+    /**
+     * Send notification when customer lands on thank you page (pending orders only).
+     */
     public function send_discord_notification($order_id) {
         $order = wc_get_order($order_id);
         if (!$order) {
@@ -308,6 +324,14 @@ class Sale_Discord_Notifications_Woo {
         }
     }
 
+    /**
+     * Send notification when order status changes.
+     *
+     * @param int    $order_id   Order ID.
+     * @param string $old_status Previous status.
+     * @param string $new_status New status.
+     * @param WC_Order|null $order Order object.
+     */
     public function send_discord_notification_on_status_change($order_id, $old_status, $new_status, $order) {
         $order_obj = is_object($order) ? $order : wc_get_order($order_id);
 
@@ -318,7 +342,7 @@ class Sale_Discord_Notifications_Woo {
         }
 
         $selected = get_option('wc_sale_discord_order_statuses', array());
-        $selected = is_array($selected) ? $selected : (array) maybe_unserialize($selected);
+        $selected = is_array($selected) ? $selected : array();
 
         $target = 'wc-' . $new_status;
         if (!in_array($target, $selected, true)) {
@@ -384,9 +408,17 @@ class Sale_Discord_Notifications_Woo {
                 return;
             }
         }
+        $order_obj->update_meta_data('_discord_sent_wc-pending_initiating', current_time('mysql'));
+        $order_obj->save();
         $this->send_discord_notification_common($order_id, 'initiating');
     }
 
+    /**
+     * Build embed and send to Discord webhook.
+     *
+     * @param int    $order_id Order ID.
+     * @param string $type     Notification type: 'new', 'update', or 'initiating'.
+     */
     private function send_discord_notification_common($order_id, $type) {
         $order = wc_get_order($order_id);
 
@@ -395,8 +427,8 @@ class Sale_Discord_Notifications_Woo {
         }
 
         $order_status_key = 'wc-' . $order->get_status();
-        $status_webhooks = maybe_unserialize(get_option('wc_sale_discord_status_webhooks', []));
-        $status_colors = maybe_unserialize(get_option('wc_sale_discord_status_colors', []));
+        $status_webhooks = get_option('wc_sale_discord_status_webhooks', []);
+        $status_colors = get_option('wc_sale_discord_status_colors', []);
         if (!is_array($status_webhooks)) {
             $status_webhooks = [];
         }
@@ -408,7 +440,6 @@ class Sale_Discord_Notifications_Woo {
 
         if (!$is_initiating) {
             $selected_statuses = get_option('wc_sale_discord_order_statuses', []);
-            $selected_statuses = maybe_unserialize($selected_statuses);
             if (!is_array($selected_statuses)) {
                 $selected_statuses = [];
             }
@@ -429,16 +460,14 @@ class Sale_Discord_Notifications_Woo {
         $order_status = ucwords(wc_get_order_status_name($order->get_status()));
         $order_total = (string) round((float) $order_data['total'], 0);
         $order_currency = $order_data['currency'];
-        $order_date = $order_data['date_created'];
-        $order_timestamp = $order_date->getTimestamp();
+        $order_date = $order_data['date_created'] ?? null;
+        $order_timestamp = ($order_date && is_object($order_date) && method_exists($order_date, 'getTimestamp')) ? $order_date->getTimestamp() : time();
         $payment_method = $order_data['payment_method_title'];
         $transaction_id = $order_data['transaction_id'];
         $billing_first_name = $order_data['billing']['first_name'];
         $billing_last_name = $order_data['billing']['last_name'];
         $billing_email = $order_data['billing']['email'];
-        
         $billing_discord = $order->get_meta('_billing_discord');
-
         $order_items = $order->get_items();
         $items_list = '';
         $first_product_image = '';
@@ -454,12 +483,11 @@ class Sale_Discord_Notifications_Woo {
             $product_total = (string) round((float) $item->get_total(), 0);
             $items_list .= "{$product_quantity}x {$product_name} - {$product_total} {$order_currency}\n";
         }
-        $items_list = rtrim($items_list, "\n");
+        $items_list = $this->truncate_discord_field(rtrim($items_list, "\n"));
 
         $order_edit_url = admin_url('post.php?post=' . $order_id . '&action=edit');
 
         $info_fields = get_option('wc_sale_discord_info_fields', array());
-        $info_fields = maybe_unserialize($info_fields);
         if (!is_array($info_fields)) {
             $info_fields = array();
         }
@@ -481,12 +509,12 @@ class Sale_Discord_Notifications_Woo {
             $embed_fields[] = ['name' => 'Payment', 'value' => "{$order_total} {$order_currency} - {$payment_method}", 'inline' => false];
         }
         if ($field_included('product')) {
-            $embed_fields[] = ['name' => 'Product', 'value' => $items_list, 'inline' => false];
+            $embed_fields[] = ['name' => 'Product', 'value' => $items_list ?: '-', 'inline' => false];
         }
         if ($field_included('product_meta')) {
             $product_meta_list = $this->get_product_meta_for_embed($order_items);
             if (!empty($product_meta_list)) {
-                $embed_fields[] = ['name' => 'Product Meta', 'value' => $product_meta_list, 'inline' => false];
+                $embed_fields[] = ['name' => 'Product Meta', 'value' => $this->truncate_discord_field($product_meta_list), 'inline' => false];
             }
         }
         if ($field_included('creation_date')) {
@@ -497,7 +525,7 @@ class Sale_Discord_Notifications_Woo {
             if (!empty($billing_discord)) {
                 $billing_value .= "\n**Discord** » {$billing_discord}";
             }
-            $embed_fields[] = ['name' => 'Billing Information', 'value' => $billing_value, 'inline' => true];
+            $embed_fields[] = ['name' => 'Billing Information', 'value' => $this->truncate_discord_field($billing_value), 'inline' => true];
         }
 
         $embed = [
@@ -507,21 +535,23 @@ class Sale_Discord_Notifications_Woo {
         ];
 
         if ($field_included('transaction_id') && !empty($transaction_id)) {
-            $embed['fields'][] = ['name' => 'Transaction ID', 'value' => $transaction_id, 'inline' => false];
+            $embed['fields'][] = ['name' => 'Transaction ID', 'value' => $this->truncate_discord_field($transaction_id), 'inline' => false];
         }
 
         if ($first_product_image && !get_option('wc_sale_discord_disable_image')) {
             $embed['image'] = ['url' => $first_product_image];
         }
 
-        $include_order_notes = get_option('wc_sale_discord_include_order_notes') || $field_included('order_notes');
+        $include_order_notes = $field_included('order_notes');
         if ($include_order_notes) {
-            $order_notes = $this->get_order_notes_for_embed($order_id);
+            $customer_only = (bool) get_option('wc_sale_discord_order_notes_customer_only', false);
+            $order_notes = $this->get_order_notes_for_embed($order_id, $order, $customer_only);
             if (!empty($order_notes)) {
-                $embed['fields'][] = ['name' => 'Order Notes', 'value' => $order_notes, 'inline' => false];
+                $embed['fields'][] = ['name' => 'Order Notes', 'value' => $this->truncate_discord_field($order_notes), 'inline' => false];
             }
         }
 
+        $embed = $this->trim_embed_to_limit($embed);
         $this->send_to_discord($webhook_url, $embed);
 
         // Track sent notifications for double-notification failsafe
@@ -529,30 +559,35 @@ class Sale_Discord_Notifications_Woo {
             $order->update_meta_data('_discord_sent_' . $order_status_key . '_new', current_time('mysql'));
             $order->save();
         }
-        if ($type === 'initiating' && $order) {
-            $order->update_meta_data('_discord_sent_wc-pending_initiating', current_time('mysql'));
-            $order->save();
-        }
     }
 
     /**
      * Get formatted order notes for Discord embed.
      * Discord embed field values have a 1024 character limit.
+     * Prefers WC_Order::get_customer_order_notes() when customer_only and available (WC 9.2+).
      *
-     * @param int $order_id Order ID.
+     * @param int        $order_id     Order ID.
+     * @param WC_Order   $order        Order object (for get_customer_order_notes when available).
+     * @param bool       $customer_only If true, only include customer notes.
      * @return string Formatted order notes or empty string.
      */
-    private function get_order_notes_for_embed(int $order_id): string {
-        if (!function_exists('wc_get_order_notes')) {
-            return '';
-        }
+    private function get_order_notes_for_embed(int $order_id, $order, bool $customer_only = false): string {
+        $notes = [];
 
-        $notes = wc_get_order_notes([
-            'order_id' => $order_id,
-            'limit'    => 20,
-            'orderby'  => 'date_created',
-            'order'    => 'DESC',
-        ]);
+        if ($customer_only && $order && method_exists($order, 'get_customer_order_notes')) {
+            $notes = $order->get_customer_order_notes();
+        } elseif (function_exists('wc_get_order_notes')) {
+            $args = [
+                'order_id' => $order_id,
+                'limit'    => 20,
+                'orderby'  => 'date_created',
+                'order'    => 'DESC',
+            ];
+            if ($customer_only) {
+                $args['type'] = 'customer';
+            }
+            $notes = wc_get_order_notes($args);
+        }
 
         if (empty($notes)) {
             return '';
@@ -588,14 +623,87 @@ class Sale_Discord_Notifications_Woo {
     }
 
     /**
+     * Trim embed to fit Discord's 6000 character limit. Truncates longest field values first.
+     *
+     * @param array $embed Embed array (title, fields, color, image).
+     * @return array Trimmed embed.
+     */
+    private function trim_embed_to_limit(array $embed): array {
+        $json = wp_json_encode($embed);
+        if ($json === false || strlen($json) <= self::DISCORD_EMBED_MAX) {
+            return $embed;
+        }
+
+        $trimmable_names = ['Order Notes', 'Product Meta', 'Product', 'Billing Information', 'Transaction ID'];
+        $embed_copy = $embed;
+        $attempt = 0;
+        $max_attempts = 50;
+
+        while (strlen(wp_json_encode($embed_copy)) > self::DISCORD_EMBED_MAX && $attempt < $max_attempts) {
+            $longest_idx = null;
+            $longest_len = 0;
+
+            foreach ($embed_copy['fields'] as $idx => $field) {
+                $val = $field['value'] ?? '';
+                if (strlen($val) > $longest_len && in_array($field['name'] ?? '', $trimmable_names, true)) {
+                    $longest_idx = $idx;
+                    $longest_len = strlen($val);
+                }
+            }
+
+            if ($longest_idx === null) {
+                if (isset($embed_copy['image']) && strlen(wp_json_encode($embed_copy)) > self::DISCORD_EMBED_MAX) {
+                    unset($embed_copy['image']);
+                }
+                while (strlen(wp_json_encode($embed_copy)) > self::DISCORD_EMBED_MAX && count($embed_copy['fields']) > 1) {
+                    array_pop($embed_copy['fields']);
+                }
+                break;
+            }
+
+            $val = $embed_copy['fields'][$longest_idx]['value'];
+            $new_len = max(50, (int) (strlen($val) * 0.75));
+            $truncated = $this->truncate_discord_field($val, $new_len);
+
+            if (strlen($truncated) >= strlen($val)) {
+                array_splice($embed_copy['fields'], $longest_idx, 1);
+            } else {
+                $embed_copy['fields'][$longest_idx]['value'] = $truncated;
+            }
+            $attempt++;
+        }
+
+        return $embed_copy;
+    }
+
+    /**
+     * Truncate string to Discord embed field limit (1024 chars).
+     *
+     * @param string $str Value to truncate.
+     * @param int $max Max length (default DISCORD_FIELD_MAX).
+     * @return string Truncated string.
+     */
+    private function truncate_discord_field(string $str, int $max = self::DISCORD_FIELD_MAX): string {
+        $len = function_exists('mb_strlen') ? mb_strlen($str, 'UTF-8') : strlen($str);
+        if ($len <= $max) {
+            return $str;
+        }
+        $cut = function_exists('mb_substr') ? mb_substr($str, 0, $max - 3, 'UTF-8') : substr($str, 0, $max - 3);
+        return $cut . '...';
+    }
+
+    /**
      * Get formatted product/item meta for Discord embed.
      *
-     * @param array $order_items Order items from WC_Order::get_items().
+     * @param array<int, WC_Order_Item> $order_items Order items from WC_Order::get_items().
      * @return string Formatted product meta or empty string.
      */
-    private function get_product_meta_for_embed($order_items): string {
+    private function get_product_meta_for_embed(array $order_items): string {
         $lines = [];
         foreach ($order_items as $item) {
+            if (!method_exists($item, 'get_formatted_meta_data')) {
+                continue;
+            }
             $meta_data = $item->get_formatted_meta_data('', true);
             if (empty($meta_data)) {
                 continue;
@@ -612,6 +720,12 @@ class Sale_Discord_Notifications_Woo {
         return implode("\n", $lines);
     }
 
+    /**
+     * POST embed payload to Discord webhook URL.
+     *
+     * @param string $webhook_url Discord webhook URL.
+     * @param array  $embed       Embed array (title, fields, color, image).
+     */
     private function send_to_discord($webhook_url, $embed) {
         $data = wp_json_encode(['embeds' => [$embed]]);
 
@@ -625,32 +739,30 @@ class Sale_Discord_Notifications_Woo {
             $args['blocking'] = true;
         }
 
-        wp_remote_post($webhook_url, $args);
+        $response = wp_remote_post($webhook_url, $args);
+        if (is_wp_error($response)) {
+            if (function_exists('wc_get_logger')) {
+                wc_get_logger()->error(
+                    'Discord webhook failed: ' . $response->get_error_message(),
+                    array('source' => 'wc-sale-discord-notifications')
+                );
+            }
+        } elseif (wp_remote_retrieve_response_code($response) >= 400) {
+            if (function_exists('wc_get_logger')) {
+                $body = wp_remote_retrieve_body($response);
+                wc_get_logger()->error(
+                    'Discord webhook returned ' . wp_remote_retrieve_response_code($response) . ': ' . substr($body, 0, 500),
+                    array('source' => 'wc-sale-discord-notifications')
+                );
+            }
+        }
     }
 
     public function plugin_action_links($links) {
-        $settings_link = '<a href="' . esc_url(admin_url('admin.php?page=wc-sale-discord-notifications')) . '">' . esc_html__('Settings', 'wc-sale-discord-notifications') . '</a>';
+        $settings_link = '<a href="' . esc_url(admin_url('admin.php?page=' . self::PAGE_SLUG)) . '">' . esc_html__('Settings', 'wc-sale-discord-notifications') . '</a>';
         array_unshift($links, $settings_link);
         return $links;
     }
 }
 
 new Sale_Discord_Notifications_Woo();
-
-if (!function_exists('wc_sale_is_wc_order')) {
-    /**
-     * Check if the post is a WooCommerce order.
-     *
-     * @param int $post_id Post id.
-     *
-     * @return bool True if the post is a WooCommerce order, false otherwise.
-     */
-    function wc_sale_is_wc_order($post_id = 0) {
-        $bool = false;
-        if ('shop_order' === \Automattic\WooCommerce\Utilities\OrderUtil::get_order_type($post_id)) {
-            $bool = true;
-        }
-        return $bool;
-    }
-}
-?>

--- a/wc-sale-discord-notifications.php
+++ b/wc-sale-discord-notifications.php
@@ -3,7 +3,7 @@
  * Plugin Name: WC Sale Discord Notifications
  * Plugin URI: https://github.com/Cral-Cactus/wc-sale-discord-notifications
  * Description: Sends a notification to a Discord channel when a sale is made or order status is changed on WooCommerce.
- * Version: 3.1.1
+ * Version: 3.1.2
  * Author: Cral_Cactus
  * Author URI: https://github.com/Cral-Cactus
  * Requires Plugins: woocommerce
@@ -474,7 +474,7 @@ class Sale_Discord_Notifications_Woo {
         $order_data = $order->get_data();
         $order_id = $order_data['id'];
         $order_status = ucwords(wc_get_order_status_name($order->get_status()));
-        $order_total = strip_tags($order->get_formatted_order_total());
+        $order_total = html_entity_decode(strip_tags($order->get_formatted_order_total()), ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $order_currency = $order_data['currency'];
         $order_date = $order_data['date_created'] ?? null;
         $order_timestamp = ($order_date && is_object($order_date) && method_exists($order_date, 'getTimestamp')) ? $order_date->getTimestamp() : time();
@@ -496,7 +496,7 @@ class Sale_Discord_Notifications_Woo {
 
             $product_name = wp_strip_all_tags($item->get_name());
             $product_quantity = $item->get_quantity();
-            $product_total = strip_tags(wc_price((float) $item->get_total(), array('currency' => $order_currency)));
+            $product_total = html_entity_decode(strip_tags(wc_price((float) $item->get_total(), array('currency' => $order_currency))), ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $items_list .= "{$product_quantity}x {$product_name} - {$product_total}\n";
         }
         $items_list = $this->truncate_discord_field(rtrim($items_list, "\n"));
@@ -512,7 +512,7 @@ class Sale_Discord_Notifications_Woo {
             return !$use_info_fields || in_array($key, $info_fields, true);
         };
 
-        $embed_title = ($type === 'initiating') ? '⏳ Initiating payment' : (($type === 'new') ? '🎉 New Order!' : '🪄 Order Update!');
+        $embed_title = $this->get_embed_title($order, $type);
 
         $embed_fields = [
             ['name' => 'Order ID', 'value' => "[#{$order_id}]({$order_edit_url})", 'inline' => false],
@@ -575,6 +575,30 @@ class Sale_Discord_Notifications_Woo {
             $order->update_meta_data('_discord_sent_' . $order_status_key . '_' . $type, current_time('mysql'));
             $order->save();
         }
+    }
+
+    /**
+     * Get embed title based on notification type and order (subscription-aware when WC Subscriptions is active).
+     *
+     * @param WC_Order $order Order object.
+     * @param string   $type  Notification type: 'new', 'update', or 'initiating'.
+     * @return string Embed title.
+     */
+    private function get_embed_title($order, string $type): string {
+        if ($type === 'initiating') {
+            $title = '⏳ Initiating payment';
+        } elseif (function_exists('wcs_order_contains_subscription')) {
+            if (wcs_order_contains_subscription($order, 'renewal')) {
+                $title = '🔄 Subscription Renewal';
+            } elseif (wcs_order_contains_subscription($order, 'parent') && $type === 'new') {
+                $title = '📦 New subscription';
+            } else {
+                $title = ($type === 'new') ? '🎉 New Order!' : '🪄 Order Update!';
+            }
+        } else {
+            $title = ($type === 'new') ? '🎉 New Order!' : '🪄 Order Update!';
+        }
+        return apply_filters('wc_sale_discord_embed_title', $title, $order, $type);
     }
 
     /**

--- a/wc-sale-discord-notifications.php
+++ b/wc-sale-discord-notifications.php
@@ -44,11 +44,12 @@ class Sale_Discord_Notifications_Woo {
     }
 
     public function add_settings_page() {
+        $capability = apply_filters('wc_sale_discord_notifications_capability', 'manage_woocommerce');
         add_submenu_page(
             'woocommerce',
             __('Discord Notifications', 'wc-sale-discord-notifications'),
             __('Discord Notifications', 'wc-sale-discord-notifications'),
-            'manage_options',
+            $capability,
             self::PAGE_SLUG,
             array($this, 'notification_settings_page')
         );
@@ -148,6 +149,7 @@ class Sale_Discord_Notifications_Woo {
             __('Disable Product Image in Embed', 'wc-sale-discord-notifications'),
             function() {
                 $disable_image = get_option('wc_sale_discord_disable_image');
+                echo '<input type="hidden" name="wc_sale_discord_disable_image" value="0" />';
                 echo '<input type="checkbox" name="wc_sale_discord_disable_image" value="1"' . checked(1, $disable_image, false) . '/>';
             },
             self::OPTION_GROUP,
@@ -159,6 +161,7 @@ class Sale_Discord_Notifications_Woo {
             __('Send notification for Initiating payments', 'wc-sale-discord-notifications'),
             function() {
                 $enabled = (int) get_option('wc_sale_discord_notify_initiating_payment', 0);
+                echo '<input type="hidden" name="wc_sale_discord_notify_initiating_payment" value="0" />';
                 echo '<input type="checkbox" name="wc_sale_discord_notify_initiating_payment" value="1"' . checked(1, $enabled, false) . '/>';
                 echo '<p class="description">' . esc_html__('Notify when a customer starts checkout (pending) before payment is completed. Uses a separate embed title from completed orders.', 'wc-sale-discord-notifications') . '</p>';
             },
@@ -179,6 +182,7 @@ class Sale_Discord_Notifications_Woo {
             __('Customer notes only', 'wc-sale-discord-notifications'),
             function () {
                 $customer_only = (int) get_option('wc_sale_discord_order_notes_customer_only', 0);
+                echo '<input type="hidden" name="wc_sale_discord_order_notes_customer_only" value="0" />';
                 echo '<input type="checkbox" name="wc_sale_discord_order_notes_customer_only" value="1"' . checked(1, $customer_only, false) . '/>';
                 echo '<p class="description">' . esc_html__('When Order Notes is included, show only customer notes (exclude internal/admin notes).', 'wc-sale-discord-notifications') . '</p>';
             },
@@ -317,7 +321,7 @@ class Sale_Discord_Notifications_Woo {
         // Only fire for pending when customer lands on thank you page (manual/slow payments)
         if ($order->get_status() === 'pending') {
             if (get_option('wc_sale_discord_notify_initiating_payment')) {
-                $this->send_discord_notification_common($order_id, 'initiating');
+                $this->maybe_send_initiating_notification($order_id, $order);
             } else {
                 $this->send_discord_notification_common($order_id, 'new');
             }
@@ -455,15 +459,27 @@ class Sale_Discord_Notifications_Woo {
             return;
         }
 
+        // 120s deduplication for new/update: skip if same event was sent recently (thank-you refresh, repeated hooks)
+        if (in_array($type, array('new', 'update'), true)) {
+            $meta_key = '_discord_sent_' . $order_status_key . '_' . $type;
+            $recent_sent = $order->get_meta($meta_key);
+            if ($recent_sent) {
+                $sent_ts = strtotime($recent_sent);
+                if ($sent_ts && (current_time('timestamp') - $sent_ts) < 120) {
+                    return;
+                }
+            }
+        }
+
         $order_data = $order->get_data();
         $order_id = $order_data['id'];
         $order_status = ucwords(wc_get_order_status_name($order->get_status()));
-        $order_total = (string) round((float) $order_data['total'], 0);
+        $order_total = strip_tags($order->get_formatted_order_total());
         $order_currency = $order_data['currency'];
         $order_date = $order_data['date_created'] ?? null;
         $order_timestamp = ($order_date && is_object($order_date) && method_exists($order_date, 'getTimestamp')) ? $order_date->getTimestamp() : time();
-        $payment_method = $order_data['payment_method_title'];
-        $transaction_id = $order_data['transaction_id'];
+        $payment_method = !empty($order_data['payment_method_title']) ? $order_data['payment_method_title'] : $order->get_payment_method();
+        $transaction_id = !empty($order_data['transaction_id']) ? $order_data['transaction_id'] : $order->get_transaction_id();
         $billing_first_name = $order_data['billing']['first_name'];
         $billing_last_name = $order_data['billing']['last_name'];
         $billing_email = $order_data['billing']['email'];
@@ -478,10 +494,10 @@ class Sale_Discord_Notifications_Woo {
                 $first_product_image = wp_get_attachment_url($product->get_image_id());
             }
 
-            $product_name = $item->get_name();
+            $product_name = wp_strip_all_tags($item->get_name());
             $product_quantity = $item->get_quantity();
-            $product_total = (string) round((float) $item->get_total(), 0);
-            $items_list .= "{$product_quantity}x {$product_name} - {$product_total} {$order_currency}\n";
+            $product_total = strip_tags(wc_price((float) $item->get_total(), array('currency' => $order_currency)));
+            $items_list .= "{$product_quantity}x {$product_name} - {$product_total}\n";
         }
         $items_list = $this->truncate_discord_field(rtrim($items_list, "\n"));
 
@@ -506,7 +522,7 @@ class Sale_Discord_Notifications_Woo {
             $embed_fields[] = ['name' => 'Status', 'value' => $order_status, 'inline' => false];
         }
         if ($field_included('payment')) {
-            $embed_fields[] = ['name' => 'Payment', 'value' => "{$order_total} {$order_currency} - {$payment_method}", 'inline' => false];
+            $embed_fields[] = ['name' => 'Payment', 'value' => "{$order_total} - {$payment_method}", 'inline' => false];
         }
         if ($field_included('product')) {
             $embed_fields[] = ['name' => 'Product', 'value' => $items_list ?: '-', 'inline' => false];
@@ -555,8 +571,8 @@ class Sale_Discord_Notifications_Woo {
         $this->send_to_discord($webhook_url, $embed);
 
         // Track sent notifications for double-notification failsafe
-        if ($type === 'new' && $order) {
-            $order->update_meta_data('_discord_sent_' . $order_status_key . '_new', current_time('mysql'));
+        if (in_array($type, array('new', 'update'), true) && $order) {
+            $order->update_meta_data('_discord_sent_' . $order_status_key . '_' . $type, current_time('mysql'));
             $order->save();
         }
     }
@@ -704,11 +720,11 @@ class Sale_Discord_Notifications_Woo {
             if (!method_exists($item, 'get_formatted_meta_data')) {
                 continue;
             }
-            $meta_data = $item->get_formatted_meta_data('', true);
+            $meta_data = $item->get_formatted_meta_data('_', true);
             if (empty($meta_data)) {
                 continue;
             }
-            $item_name = $item->get_name();
+            $item_name = wp_strip_all_tags($item->get_name());
             foreach ($meta_data as $meta) {
                 $key = isset($meta->display_key) ? $meta->display_key : '';
                 $val = isset($meta->display_value) ? wp_strip_all_tags($meta->display_value) : '';
@@ -730,13 +746,14 @@ class Sale_Discord_Notifications_Woo {
         $data = wp_json_encode(['embeds' => [$embed]]);
 
         $args = [
-            'body' => $data,
+            'body'    => $data,
             'headers' => ['Content-Type' => 'application/json'],
-            'timeout' => 60,
+            'timeout' => 10,
+            'blocking' => false,
         ];
-
         if (get_option('wc_sale_discord_force_blocking')) {
             $args['blocking'] = true;
+            $args['timeout']  = 60;
         }
 
         $response = wp_remote_post($webhook_url, $args);


### PR DESCRIPTION
## Summary
Adds new notification options and behavior for WooCommerce order status changes.

## Changes
### Initiating Payment Notification
- New setting: **"Send notification for Initiating payments"**
- Sends a distinct "⏳ Initiating payment" notification when an order is placed with pending status (payment started but not completed)
- When payment completes: sends "🎉 New Order!" for processing
- Uses multiple triggers: `woocommerce_thankyou`, `woocommerce_order_status_changed`, `woocommerce_order_status_pending`, `woocommerce_checkout_order_processed` for reliable delivery
- 
### Order Notes
- Adds **Order Notes** to the embed fields (customer and internal notes)
- Configurable via the new "Embed Fields" option
- 
### Embed Fields
- New setting to choose which fields appear in the Discord embed (status, payment, product, product meta, creation date, billing, transaction ID, order notes)
- 
### Bug Fixes
- **Pending → Processing**: now correctly sends "New Order" instead of "Order Update"
- **Amount rounding**: order totals and product totals are rounded to whole numbers

### Other
- Duplicate protection updated via 120-second meta check for initiating notifications